### PR TITLE
add parenthesis support to content-disposition filename field

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ var quoteRegExp = /([\\"])/g
  * OCTET         = <any 8-bit sequence of data>
  */
 
-var paramRegExp = /; *([!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+) *= *("(?:[ !\x23-\x5b\x5d-\x7e\x80-\xff]|\\[\x20-\x7e])*"|[!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+) */g
+var paramRegExp = /; *([!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+) *= *("(?:[ !\x23-\x5b\x5d-\x7e\x80-\xff]|\\[\x20-\x7e])*"|[!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~\(\)]+) */g
 var textRegExp = /^[\x20-\x7e\x80-\xff]+$/
 var tokenRegExp = /^[!#$%&'\*\+\-\.0-9A-Z\^_`a-z\|~]+$/
 


### PR DESCRIPTION
file name may contain parenthesis and currently content-disposition does not support it.