### PR TITLE
Avoid using deprecated Buffer API on newer Node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,14 @@ function decodefield (str) {
       value = getlatin1(binary)
       break
     case 'utf-8':
-      value = new Buffer(binary, 'binary').toString('utf8')
+      if (Buffer.from && Buffer.from !== Uint8Array.from) {
+        // Node.js 4.5.0 or newer
+        value = Buffer.from(binary, 'binary').toString('utf8')
+      } else {
+        // Old Node.js versions
+        // `binary` is always a string here, so this is safe
+        buf = value = new Buffer(binary, 'binary').toString('utf8')
+      }
       break
     default:
       throw new TypeError('unsupported charset in extended field')


### PR DESCRIPTION
This avoids using Buffer constructor API on newer Node.js versions.

To achieve that, `Buffer.from` presence is checked, with validation that it's not the same method as `Uint8Array.from`.

The `!number` type-guard for older Node.js versions is excluded and replaced with a comment, as `binary` is always a string there and this looks to be potentially hot code path.

Given this module popularity and the fact that old Buffer constructor API was used in a single place, I decided to just feature-detect it in-place instead of pulling in polyfill deps.
Another way would be to just use `Buffer.from` and do `var Buffer = require('safe-buffer')`;

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Tracking: https://github.com/nodejs/node/issues/19079