### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ function format (obj) {
     for (var i = 0; i < params.length; i++) {
       param = params[i]
 
-      var val = param.substr(-1) === '*'
+      var val = param.slice(-1) === '*'
         ? ustring(parameters[param])
         : qstring(parameters[param])
 
@@ -332,7 +332,7 @@ function parse (string) {
   var value
 
   // calculate index to start at
-  index = PARAM_REGEXP.lastIndex = match[0].substr(-1) === ';'
+  index = PARAM_REGEXP.lastIndex = match[0].slice(-1) === ';'
     ? index - 1
     : index
 
@@ -369,7 +369,7 @@ function parse (string) {
     if (value[0] === '"') {
       // remove quotes and escapes
       value = value
-        .substr(1, value.length - 2)
+        .slice(1, -1)
         .replace(QESC_REGEXP, '$1')
     }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.