### PR TITLE
Remove dependency `safe-buffer`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+unreleased
+=================
+  * Remove dependency `safe-buffer`
+
 1.0.0 / 2024-08-31
 ==================
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ module.exports.parse = parse
  */
 
 var basename = require('path').basename
-var Buffer = require('safe-buffer').Buffer
 
 /**
  * RegExp to match non attr-char, *after* encodeURIComponent (i.e. not including "%")

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "res"
   ],
   "repository": "jshttp/content-disposition",
-  "dependencies": {
-    "safe-buffer": "5.2.1"
-  },
   "devDependencies": {
     "deep-equal": "1.0.1",
     "eslint": "7.32.0",


### PR DESCRIPTION
This PR removes the `safe-buffer` package from `dependencies` as it's no longer needed since `content-disposition` no longer supports Node.js versions older than 18.0.0. There are no instances of `new Buffer(...)` usage in the repository.