### PR TITLE
replace `mocha` and `nyc` with native node test runner and `c8`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,7 @@ jobs:
 
     - name: Run tests
       shell: bash
-      run: |
-        if npm -ps ls nyc | grep -q nyc; then
-          npm run test-ci
-        else
-          npm test
-        fi
+      run: npm run test-ci
 
     - name: Lint code
       if: steps.list_env.outputs.eslint != ''
@@ -83,7 +78,6 @@ jobs:
 
     - name: Collect code coverage
       uses: coverallsapp/github-action@master
-      if: steps.list_env.outputs.nyc != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: run-${{ matrix.test_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
         echo "NPM version: $(npm -v)"
 
     - name: Run tests
-      shell: bash
       run: npm run test-ci
 
     - name: Upload code coverage

--- a/package.json
+++ b/package.json
@@ -12,16 +12,14 @@
   ],
   "repository": "jshttp/content-disposition",
   "devDependencies": {
-    "deep-equal": "1.0.1",
+    "c8": "^10.1.2",
     "eslint": "7.32.0",
     "eslint-config-standard": "13.0.1",
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-markdown": "2.2.1",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
-    "eslint-plugin-standard": "4.1.0",
-    "mocha": "^9.2.2",
-    "nyc": "15.1.0"
+    "eslint-plugin-standard": "4.1.0"
   },
   "files": [
     "LICENSE",
@@ -34,8 +32,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --reporter spec --bail --check-leaks test/",
-    "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test": "node --test --test-reporter spec",
+    "test-ci": "c8 --reporter=lcovonly --reporter=text npm test",
+    "test-cov": "c8 --reporter=html --reporter=text npm test"
   }
 }

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,2 +1,0 @@
-env:
-  mocha: true

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
-
 var assert = require('assert')
 var contentDisposition = require('..')
-var deepEqual = require('deep-equal')
+var { describe, it } = require('node:test')
 
 describe('contentDisposition()', function () {
   it('should create an attachment header', function () {
@@ -204,38 +203,38 @@ describe('contentDisposition.parse(string)', function () {
     })
 
     it('should parse "attachment"', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment'), {
+      assert.deepEqual(contentDisposition.parse('attachment'), {
         type: 'attachment',
         parameters: {}
-      }))
+      })
     })
 
     it('should parse "inline"', function () {
-      assert.ok(deepEqual(contentDisposition.parse('inline'), {
+      assert.deepEqual(contentDisposition.parse('inline'), {
         type: 'inline',
         parameters: {}
-      }))
+      })
     })
 
     it('should parse "form-data"', function () {
-      assert.ok(deepEqual(contentDisposition.parse('form-data'), {
+      assert.deepEqual(contentDisposition.parse('form-data'), {
         type: 'form-data',
         parameters: {}
-      }))
+      })
     })
 
     it('should parse with trailing LWS', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment \t '), {
+      assert.deepEqual(contentDisposition.parse('attachment \t '), {
         type: 'attachment',
         parameters: {}
-      }))
+      })
     })
 
     it('should normalize to lower-case', function () {
-      assert.ok(deepEqual(contentDisposition.parse('ATTACHMENT'), {
+      assert.deepEqual(contentDisposition.parse('ATTACHMENT'), {
         type: 'attachment',
         parameters: {}
-      }))
+      })
     })
   })
 
@@ -278,52 +277,52 @@ describe('contentDisposition.parse(string)', function () {
     })
 
     it('should lower-case parameter name', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; FILENAME="plans.pdf"'), {
+      assert.deepEqual(contentDisposition.parse('attachment; FILENAME="plans.pdf"'), {
         type: 'attachment',
         parameters: { filename: 'plans.pdf' }
-      }))
+      })
     })
 
     it('should parse quoted parameter value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename="plans.pdf"'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename="plans.pdf"'), {
         type: 'attachment',
         parameters: { filename: 'plans.pdf' }
-      }))
+      })
     })
 
     it('should parse & unescape quoted value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename="the \\"plans\\".pdf"'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename="the \\"plans\\".pdf"'), {
         type: 'attachment',
         parameters: { filename: 'the "plans".pdf' }
-      }))
+      })
     })
 
     it('should include all parameters', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename="plans.pdf"; foo=bar'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename="plans.pdf"; foo=bar'), {
         type: 'attachment',
         parameters: { filename: 'plans.pdf', foo: 'bar' }
-      }))
+      })
     })
 
     it('should parse parameters separated with any LWS', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment;filename="plans.pdf" \t;    \t\t foo=bar'), {
+      assert.deepEqual(contentDisposition.parse('attachment;filename="plans.pdf" \t;    \t\t foo=bar'), {
         type: 'attachment',
         parameters: { filename: 'plans.pdf', foo: 'bar' }
-      }))
+      })
     })
 
     it('should parse token filename', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename=plans.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename=plans.pdf'), {
         type: 'attachment',
         parameters: { filename: 'plans.pdf' }
-      }))
+      })
     })
 
     it('should parse ISO-8859-1 filename', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename="£ rates.pdf"'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename="£ rates.pdf"'), {
         type: 'attachment',
         parameters: { filename: '£ rates.pdf' }
-      }))
+      })
     })
   })
 
@@ -334,10 +333,10 @@ describe('contentDisposition.parse(string)', function () {
     })
 
     it('should parse UTF-8 extended parameter value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
+      })
     })
 
     it('should parse UTF8 extended parameter value', function () {
@@ -348,32 +347,32 @@ describe('contentDisposition.parse(string)', function () {
     })
 
     it('should parse UTF-8 extended parameter value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E4%20rates.pdf'), {
+      })
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E4%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '\ufffd rates.pdf' }
-      }))
+      })
     })
 
     it('should parse ISO-8859-1 extended parameter value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=ISO-8859-1\'\'%A3%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=ISO-8859-1\'\'%A3%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '£ rates.pdf' }
-      }))
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=ISO-8859-1\'\'%82%20rates.pdf'), {
+      })
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=ISO-8859-1\'\'%82%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '? rates.pdf' }
-      }))
+      })
     })
 
     it('should not be case-sensitive for charset', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=utf-8\'\'%E2%82%AC%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=utf-8\'\'%E2%82%AC%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
+      })
     })
 
     it('should reject unsupported charset', function () {
@@ -382,31 +381,31 @@ describe('contentDisposition.parse(string)', function () {
     })
 
     it('should parse with embedded language', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'en\'%E2%82%AC%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'en\'%E2%82%AC%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
+      })
     })
 
     it('should prefer extended parameter value', function () {
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
+      assert.deepEqual(contentDisposition.parse('attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
-      assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf; filename="EURO rates.pdf"'), {
+      })
+      assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf; filename="EURO rates.pdf"'), {
         type: 'attachment',
         parameters: { filename: '€ rates.pdf' }
-      }))
+      })
     })
   })
 
   describe('from TC 2231', function () {
     describe('Disposition-Type Inline', function () {
       it('should parse "inline"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('inline'), {
+        assert.deepEqual(contentDisposition.parse('inline'), {
           type: 'inline',
           parameters: {}
-        }))
+        })
       })
 
       it('should reject ""inline""', function () {
@@ -415,33 +414,33 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "inline; filename="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('inline; filename="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('inline; filename="foo.html"'), {
           type: 'inline',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should parse "inline; filename="Not an attachment!""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('inline; filename="Not an attachment!"'), {
+        assert.deepEqual(contentDisposition.parse('inline; filename="Not an attachment!"'), {
           type: 'inline',
           parameters: { filename: 'Not an attachment!' }
-        }))
+        })
       })
 
       it('should parse "inline; filename="foo.pdf""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('inline; filename="foo.pdf"'), {
+        assert.deepEqual(contentDisposition.parse('inline; filename="foo.pdf"'), {
           type: 'inline',
           parameters: { filename: 'foo.pdf' }
-        }))
+        })
       })
     })
 
     describe('Disposition-Type Attachment', function () {
       it('should parse "attachment"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment'), {
+        assert.deepEqual(contentDisposition.parse('attachment'), {
           type: 'attachment',
           parameters: {}
-        }))
+        })
       })
 
       it('should reject ""attachment""', function () {
@@ -450,80 +449,80 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "ATTACHMENT"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('ATTACHMENT'), {
+        assert.deepEqual(contentDisposition.parse('ATTACHMENT'), {
           type: 'attachment',
           parameters: {}
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="0000000000111111111122222""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="0000000000111111111122222"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="0000000000111111111122222"'), {
           type: 'attachment',
           parameters: { filename: '0000000000111111111122222' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="00000000001111111111222222222233333""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="00000000001111111111222222222233333"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="00000000001111111111222222222233333"'), {
           type: 'attachment',
           parameters: { filename: '00000000001111111111222222222233333' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="f\\oo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="f\\oo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="f\\oo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="\\"quoting\\" tested.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="\\"quoting\\" tested.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="\\"quoting\\" tested.html"'), {
           type: 'attachment',
           parameters: { filename: '"quoting" tested.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="Here\'s a semicolon;.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="Here\'s a semicolon;.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="Here\'s a semicolon;.html"'), {
           type: 'attachment',
           parameters: { filename: 'Here\'s a semicolon;.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; foo="bar"; filename="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; foo="bar"; filename="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; foo="bar"; filename="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html', foo: 'bar' }
-        }))
+        })
       })
 
       it('should parse "attachment; foo="\\"\\\\";filename="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; foo="\\"\\\\";filename="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; foo="\\"\\\\";filename="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html', foo: '"\\' }
-        }))
+        })
       })
 
       it('should parse "attachment; FILENAME="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; FILENAME="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; FILENAME="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename=foo.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename=foo.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename=foo.html'), {
           type: 'attachment',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should reject "attachment; filename=foo,bar.html"', function () {
@@ -547,73 +546,73 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; filename=\'foo.bar\'', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename=\'foo.bar\''), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename=\'foo.bar\''), {
           type: 'attachment',
           parameters: { filename: '\'foo.bar\'' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo-ä.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-ä.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-ä.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo-Ã¤.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-Ã¤.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-Ã¤.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-Ã¤.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo-%41.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-%41.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-%41.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-%41.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="50%.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="50%.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="50%.html"'), {
           type: 'attachment',
           parameters: { filename: '50%.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo-%\\41.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-%\\41.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-%\\41.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-%41.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; name="foo-%41.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; name="foo-%41.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; name="foo-%41.html"'), {
           type: 'attachment',
           parameters: { name: 'foo-%41.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="ä-%41.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="ä-%41.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="ä-%41.html"'), {
           type: 'attachment',
           parameters: { filename: 'ä-%41.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="foo-%c3%a4-%e2%82%ac.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-%c3%a4-%e2%82%ac.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-%c3%a4-%e2%82%ac.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-%c3%a4-%e2%82%ac.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename ="foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename ="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename ="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html' }
-        }))
+        })
       })
 
       it('should reject "attachment; filename="foo.html"; filename="bar.html"', function () {
@@ -717,72 +716,72 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; xfilename=foo.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; xfilename=foo.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; xfilename=foo.html'), {
           type: 'attachment',
           parameters: { xfilename: 'foo.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="/foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="/foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="/foo.html"'), {
           type: 'attachment',
           parameters: { filename: '/foo.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename="\\\\foo.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="\\\\foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="\\\\foo.html"'), {
           type: 'attachment',
           parameters: { filename: '\\foo.html' }
-        }))
+        })
       })
     })
 
     describe('Additional Parameters', function () {
       it('should parse "attachment; creation-date="Wed, 12 Feb 1997 16:29:51 -0500""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"'), {
           type: 'attachment',
           parameters: { 'creation-date': 'Wed, 12 Feb 1997 16:29:51 -0500' }
-        }))
+        })
       })
 
       it('should parse "attachment; modification-date="Wed, 12 Feb 1997 16:29:51 -0500""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; modification-date="Wed, 12 Feb 1997 16:29:51 -0500"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; modification-date="Wed, 12 Feb 1997 16:29:51 -0500"'), {
           type: 'attachment',
           parameters: { 'modification-date': 'Wed, 12 Feb 1997 16:29:51 -0500' }
-        }))
+        })
       })
     })
 
     describe('Disposition-Type Extension', function () {
       it('should parse "foobar"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('foobar'), {
+        assert.deepEqual(contentDisposition.parse('foobar'), {
           type: 'foobar',
           parameters: {}
-        }))
+        })
       })
 
       it('should parse "attachment; example="filename=example.txt""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; example="filename=example.txt"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; example="filename=example.txt"'), {
           type: 'attachment',
           parameters: { example: 'filename=example.txt' }
-        }))
+        })
       })
     })
 
     describe('RFC 2231/5987 Encoding: Character Sets', function () {
       it('should parse "attachment; filename*=iso-8859-1\'\'foo-%E4.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=iso-8859-1\'\'foo-%E4.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=iso-8859-1\'\'foo-%E4.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*=UTF-8\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-%c3%a4-%e2%82%ac.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-%c3%a4-%e2%82%ac.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä-€.html' }
-        }))
+        })
       })
 
       it('should reject "attachment; filename*=\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
@@ -791,24 +790,24 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; filename*=UTF-8\'\'foo-a%cc%88.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-a%cc%88.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-a%cc%88.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*=iso-8859-1\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=iso-8859-1\'\'foo-%c3%a4-%e2%82%ac.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=iso-8859-1\'\'foo-%c3%a4-%e2%82%ac.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-Ã¤-â?¬.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*=utf-8\'\'foo-%E4.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=utf-8\'\'foo-%E4.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=utf-8\'\'foo-%E4.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-\ufffd.html' }
-        }))
+        })
       })
 
       it('should reject "attachment; filename *=UTF-8\'\'foo-%c3%a4.html"', function () {
@@ -817,17 +816,17 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; filename*= UTF-8\'\'foo-%c3%a4.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*= UTF-8\'\'foo-%c3%a4.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*= UTF-8\'\'foo-%c3%a4.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename* =UTF-8\'\'foo-%c3%a4.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename* =UTF-8\'\'foo-%c3%a4.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename* =UTF-8\'\'foo-%c3%a4.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should reject "attachment; filename*="UTF-8\'\'foo-%c3%a4.html""', function () {
@@ -856,98 +855,98 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; filename*=UTF-8\'\'A-%2541.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'A-%2541.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'A-%2541.html'), {
           type: 'attachment',
           parameters: { filename: 'A-%41.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*=UTF-8\'\'%5cfoo.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%5cfoo.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'%5cfoo.html'), {
           type: 'attachment',
           parameters: { filename: '\\foo.html' }
-        }))
+        })
       })
     })
 
     describe('RFC2231 Encoding: Continuations', function () {
       it('should parse "attachment; filename*0="foo."; filename*1="html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0="foo."; filename*1="html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0="foo."; filename*1="html"'), {
           type: 'attachment',
           parameters: { 'filename*0': 'foo.', 'filename*1': 'html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*0="foo"; filename*1="\\b\\a\\r.html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*1="\\b\\a\\r.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*1="\\b\\a\\r.html"'), {
           type: 'attachment',
           parameters: { 'filename*0': 'foo', 'filename*1': 'bar.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*0*=UTF-8\'\'foo-%c3%a4; filename*1=".html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0*=UTF-8\'\'foo-%c3%a4; filename*1=".html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0*=UTF-8\'\'foo-%c3%a4; filename*1=".html"'), {
           type: 'attachment',
           parameters: { 'filename*0*': 'UTF-8\'\'foo-%c3%a4', 'filename*1': '.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*0="foo"; filename*01="bar""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*01="bar"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*01="bar"'), {
           type: 'attachment',
           parameters: { 'filename*0': 'foo', 'filename*01': 'bar' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*0="foo"; filename*2="bar""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*2="bar"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0="foo"; filename*2="bar"'), {
           type: 'attachment',
           parameters: { 'filename*0': 'foo', 'filename*2': 'bar' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*1="foo."; filename*2="html""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*1="foo."; filename*2="html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*1="foo."; filename*2="html"'), {
           type: 'attachment',
           parameters: { 'filename*1': 'foo.', 'filename*2': 'html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*1="bar"; filename*0="foo""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*1="bar"; filename*0="foo"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*1="bar"; filename*0="foo"'), {
           type: 'attachment',
           parameters: { 'filename*1': 'bar', 'filename*0': 'foo' }
-        }))
+        })
       })
     })
 
     describe('RFC2231 Encoding: Fallback Behaviour', function () {
       it('should parse "attachment; filename="foo-ae.html"; filename*=UTF-8\'\'foo-%c3%a4.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="foo-ae.html"; filename*=UTF-8\'\'foo-%c3%a4.html'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="foo-ae.html"; filename*=UTF-8\'\'foo-%c3%a4.html'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*=UTF-8\'\'foo-%c3%a4.html; filename="foo-ae.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-%c3%a4.html; filename="foo-ae.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*=UTF-8\'\'foo-%c3%a4.html; filename="foo-ae.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo-ä.html' }
-        }))
+        })
       })
 
       it('should parse "attachment; filename*0*=ISO-8859-15\'\'euro-sign%3d%a4; filename*=ISO-8859-1\'\'currency-sign%3d%a4', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename*0*=ISO-8859-15\'\'euro-sign%3d%a4; filename*=ISO-8859-1\'\'currency-sign%3d%a4'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename*0*=ISO-8859-15\'\'euro-sign%3d%a4; filename*=ISO-8859-1\'\'currency-sign%3d%a4'), {
           type: 'attachment',
           parameters: { filename: 'currency-sign=¤', 'filename*0*': 'ISO-8859-15\'\'euro-sign%3d%a4' }
-        }))
+        })
       })
 
       it('should parse "attachment; foobar=x; filename="foo.html"', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; foobar=x; filename="foo.html"'), {
+        assert.deepEqual(contentDisposition.parse('attachment; foobar=x; filename="foo.html"'), {
           type: 'attachment',
           parameters: { filename: 'foo.html', foobar: 'x' }
-        }))
+        })
       })
     })
 
@@ -958,10 +957,10 @@ describe('contentDisposition.parse(string)', function () {
       })
 
       it('should parse "attachment; filename="=?ISO-8859-1?Q?foo-=E4.html?=""', function () {
-        assert.ok(deepEqual(contentDisposition.parse('attachment; filename="=?ISO-8859-1?Q?foo-=E4.html?="'), {
+        assert.deepEqual(contentDisposition.parse('attachment; filename="=?ISO-8859-1?Q?foo-=E4.html?="'), {
           type: 'attachment',
           parameters: { filename: '=?ISO-8859-1?Q?foo-=E4.html?=' }
-        }))
+        })
       })
     })
   })


### PR DESCRIPTION
This PR refactors the test setup by replacing Mocha and NYC with Node.js's native test runner (`node:test`) and [`c8`](https://www.npmjs.com/package/c8) for coverage reporting.

**Key Changes:**
- Replaced Mocha and NYC with the native Node.js test runner and [`c8`](https://www.npmjs.com/package/c8) for code coverage.
- Updated test scripts to align with the new setup, improving maintainability and reducing reliance on external libraries.
- Replaced `deep-equal` with native `assert.deepEqual`.
- Updates the CI pipeline

**Benefits:**  
These changes modernize the testing framework, reduce external dependencies, and uphold code coverage standards using built-in Node.js capabilities.