### PR TITLE
refactor: use simplified `basename` function and remove dependency on `node:path`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+=================
+
+  * refactor: use simplified `basename` function and remove dependency on `node:path`
+
 1.0.1 / 2025-11-18
 =================
 

--- a/index.js
+++ b/index.js
@@ -15,13 +15,6 @@ module.exports = contentDisposition
 module.exports.parse = parse
 
 /**
- * Module dependencies.
- * @private
- */
-
-var basename = require('path').basename
-
-/**
  * RegExp to match non attr-char, *after* encodeURIComponent (i.e. not including "%")
  * @private
  */
@@ -455,4 +448,30 @@ function ustring (val) {
 function ContentDisposition (type, parameters) {
   this.type = type
   this.parameters = parameters
+}
+
+/**
+  * Return the last portion of a path
+  *
+  * @param {string} path
+  * @returns {string}
+  */
+function basename (path) {
+  const normalized = path.replaceAll('\\', '/')
+
+  let end = normalized.length
+  while (end > 0 && normalized[end - 1] === '/') {
+    end--
+  }
+
+  if (end === 0) {
+    return ''
+  }
+
+  let start = end - 1
+  while (start >= 0 && normalized[start] !== '/') {
+    start--
+  }
+
+  return normalized.slice(start + 1, end)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -19,8 +19,48 @@ describe('contentDisposition(filename)', function () {
       'attachment; filename="plans.pdf"')
   })
 
-  it('should use the basename of the string', function () {
+  it('should use the basename of a posix path', function () {
     assert.strictEqual(contentDisposition('/path/to/plans.pdf'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path', function () {
+    assert.strictEqual(contentDisposition('\\path\\to\\plans.pdf'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path with drive letter', function () {
+    assert.strictEqual(contentDisposition('C:\\path\\to\\plans.pdf'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a posix path with trailing slash', function () {
+    assert.strictEqual(contentDisposition('/path/to/plans.pdf/'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path with trailing slash', function () {
+    assert.strictEqual(contentDisposition('\\path\\to\\plans.pdf\\'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path with drive letter and trailing slash', function () {
+    assert.strictEqual(contentDisposition('C:\\path\\to\\plans.pdf\\'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a posix path with trailing slashes', function () {
+    assert.strictEqual(contentDisposition('/path/to/plans.pdf///'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path with trailing slashes', function () {
+    assert.strictEqual(contentDisposition('\\path\\to\\plans.pdf\\\\\\'),
+      'attachment; filename="plans.pdf"')
+  })
+
+  it('should use the basename of a windows path with drive letter and trailing slashes', function () {
+    assert.strictEqual(contentDisposition('C:\\path\\to\\plans.pdf\\\\\\'),
       'attachment; filename="plans.pdf"')
   })
 
@@ -137,8 +177,18 @@ describe('contentDisposition(filename, options)', function () {
           'attachment; filename="plans.pdf"')
       })
 
-      it('should use the basename of the string', function () {
+      it('should use the basename of a posix path', function () {
         assert.strictEqual(contentDisposition('€ rates.pdf', { fallback: '/path/to/EURO rates.pdf' }),
+          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf')
+      })
+
+      it('should use the basename of a windows path', function () {
+        assert.strictEqual(contentDisposition('€ rates.pdf', { fallback: '\\path\\to\\EURO rates.pdf' }),
+          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf')
+      })
+
+      it('should use the basename of a windows path with drive letter', function () {
+        assert.strictEqual(contentDisposition('€ rates.pdf', { fallback: 'C:\\path\\to\\EURO rates.pdf' }),
           'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf')
       })
 


### PR DESCRIPTION
This PR introduces a lightweight `basename` function to remove the dependency on `node:path`, enabling usage in environments like the browser. Additionally, new test cases have been added to validate the function's handling of various path formats.

Ref: https://github.com/expressjs/discussions/issues/331