### PR TITLE
chore: remove HISTORY.md from tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "eslint-plugin-standard": "4.1.0"
   },
   "files": [
-    "LICENSE",
-    "HISTORY.md",
-    "README.md",
     "index.js"
   ],
   "engines": {


### PR DESCRIPTION
This PR removes `HISTORY.md` from published tarball content. It also removes [automatically included files](https://docs.npmjs.com/cli/v11/commands/npm-publish#files-included-in-package) (`README.md` & `LICENSE`) from the `files` array. 