### PR TITLE
chore: update eslint dependencies to support newer syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   },
   "devDependencies": {
     "c8": "^10.1.2",
-    "eslint": "7.32.0",
-    "eslint-config-standard": "13.0.1",
-    "eslint-plugin-import": "2.25.3",
-    "eslint-plugin-markdown": "2.2.1",
-    "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "5.2.0",
-    "eslint-plugin-standard": "4.1.0"
+    "eslint": "^8.57.1",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-markdown": "^3.0.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^6.6.0",
+    "eslint-plugin-standard": "^4.1.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This aligns the eslint dependencies with the versions used by [`body-parser`](https://github.com/expressjs/body-parser/blob/master/package.json) to support newer syntax. This is a temporary fix until we decide on a linter configuration (Ref: https://github.com/expressjs/discussions/issues/327)

I had issues when refactoring some parts of the code to use newer syntax like optional chaining. 