### PR TITLE
feat: add types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,23 @@ jobs:
 
       - name: Lint code
         run: npm run lint
+        
+  test-types:
+    name: Test Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Node.js dependencies
+        run: npm install --ignore-scripts --include=dev
+
+      - name: Test Types
+        run: npm run test-types
 
   test:    
     name: Test - Node.js ${{ matrix.node-version }}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+declare namespace contentDisposition {
+  /**
+   * Class for parsed Content-Disposition header for v8 optimization
+   */
+  interface ContentDisposition {
+    /**
+     * The disposition type (always lower case)
+     */
+    type: "attachment" | "inline" | string;
+    /**
+     * An object of the parameters in the disposition
+     * (name of parameter always lower case and extended versions replace non-extended versions)
+     */
+    parameters: { [key: string]: string };
+  }
+
+  interface Options {
+    /**
+     * Specifies the disposition type.
+     * This can also be "inline", or any other value (all values except `inline` are treated like attachment,
+     * but can convey additional information if both parties agree to it).
+     * The `type` is normalized to lower-case.
+     * @default 'attachment'
+     */
+    type?: "attachment" | "inline" | string | undefined;
+    /**
+     * If the filename option is outside ISO-8859-1,
+     * then the file name is actually stored in a supplemental field for clients
+     * that support Unicode file names and a ISO-8859-1 version of the file name is automatically generated
+     * @default true
+     */
+    fallback?: string | boolean | undefined;
+  }
+
+  /**
+   * Parse a Content-Disposition header string
+   */
+  function parse(contentDispositionHeader: string): ContentDisposition;
+}
+
+/**
+ * Create an attachment `Content-Disposition` header value using the given file name, if supplied.
+ * The `filename` is optional and if no file name is desired, but you want to specify options, set `filename` to undefined.
+ */
+declare function contentDisposition(
+  filename?: string,
+  options?: contentDisposition.Options
+): string;
+
+export = contentDisposition;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
     "type": "opencollective",
     "url": "https://opencollective.com/express"
   },
+  "type": "commonjs",
+  "main": "index.js",
+  "types": "index.d.ts",
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.2",
+    "@tsconfig/node18": "^18.2.6",
     "c8": "^10.1.2",
     "eslint": "7.32.0",
     "eslint-config-standard": "13.0.1",
@@ -23,21 +28,25 @@
     "eslint-plugin-markdown": "2.2.1",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",
-    "eslint-plugin-standard": "4.1.0"
+    "eslint-plugin-standard": "4.1.0",
+    "expect-type": "^1.3.0",
+    "typescript": "^5.9.3"
   },
   "files": [
     "LICENSE",
     "HISTORY.md",
     "README.md",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">=18"
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "node --test --test-reporter spec",
+    "test": "node --test --test-reporter spec ./test/test.js",
     "test-ci": "c8 --reporter=lcovonly --reporter=text npm test",
-    "test-cov": "c8 --reporter=html --reporter=text npm test"
+    "test-cov": "c8 --reporter=html --reporter=text npm test",
+    "test-types": "tsc --noEmit && attw --pack"
   }
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf } from "expect-type";
+import contentDisposition from "..";
+
+const noParams = contentDisposition();
+expectTypeOf(noParams).toBeString();
+const withFilenameNoOptions = contentDisposition("EURO rates.txt");
+expectTypeOf(withFilenameNoOptions).toBeString();
+const withFilenameAndOptions = contentDisposition("€ rates.txt", { type: "attachment", fallback: "EURO rates.txt" });
+expectTypeOf(withFilenameAndOptions).toBeString();
+const noFilename = contentDisposition(undefined, { type: "attachment", fallback: true });
+expectTypeOf(noFilename).toBeString();
+
+const { parse } = contentDisposition;
+
+const res = parse("attachment; filename=\"EURO rates.txt\"");
+
+expectTypeOf(res.type).toBeString();
+expectTypeOf(res.parameters).toEqualTypeOf<{ [key: string]: string }>();
+
+if ("filename" in res.parameters) {
+    expectTypeOf(res.parameters["filename"]).toBeString();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "include": ["index.d.ts", "test/types.ts"]
+}


### PR DESCRIPTION
This PR adds type definitions to `content-dispotition`. It includes the following changes: 
- moving types from [`@types/content-disposition`](https://www.npmjs.com/package/@types/content-disposition) into the repository (https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/content-disposition)
- adding `type`, `main` and `types` field to `package.json`
- adding a `tsconfig.json` which extends `@tsconfig/node18` from https://github.com/tsconfig/bases
- adapting type tests with [`@arethetypeswrong/cli`](https://www.npmjs.com/package/@arethetypeswrong/cli) and [`expect-type`](https://www.npmjs.com/package/expect-type)

Ref: https://github.com/expressjs/typescript-wg/issues/1

I plan to further improve the types once they are merged.

cc  @bjohansebas @jonchurch @clicktodev