### PR TITLE
feat: add TextDecoder fallback for extended parameter UTF-8 decoding when Buffer is unavailable

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,10 @@ extends:
   - plugin:markdown/recommended
 plugins:
   - markdown
+parserOptions:
+  ecmaVersion: 2021
+globals:
+  globalThis: readonly
 overrides:
   - files: '**/*.md'
     processor: 'markdown/markdown'


### PR DESCRIPTION
I added a browser-compatible UTF-8 decode fallback using `TextDecoder` when `Buffer` is unavailable (like in Browser Environments). I lazy-initialize and reuse the UTF-8 `TextDecoder` for performance. I also added the necesarry tests to cover the `TextDecoder` path by simulating environments without `Buffer`. 