### PR TITLE
Specify behavior when only slashes or backslashes are passed as filename parameter

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,16 @@ describe('contentDisposition(filename)', function () {
       'attachment; filename="plans.pdf"')
   })
 
+  it('should use the basename of a posix path with only slashes', function () {
+    assert.strictEqual(contentDisposition('///'),
+      'attachment; filename*=UTF-8\'\'')
+  })
+
+  it('should use the basename of a windows path with only slashes', function () {
+    assert.strictEqual(contentDisposition('\\\\\\'),
+      'attachment; filename*=UTF-8\'\'')
+  })
+
   describe('when "filename" is US-ASCII', function () {
     it('should only include filename parameter', function () {
       assert.strictEqual(contentDisposition('plans.pdf'),


### PR DESCRIPTION
I'm opening this PR to discuss how we should handle filenames consisting only of slashes or backslashes. When a filename contains only slashes, the function returns an invalid header in my opinion:

`attachment; filename*=UTF-8''`

Is this the desired behavior, or should we handle it differently? Should we add explicit validation to reject invalid filenames?