### PR TITLE
Null object performance bump

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,15 @@ export interface CreateOptions {
 }
 
 /**
+ * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
+ */
+const NullObject = /* @__PURE__ */ (() => {
+  const C = function () {};
+  C.prototype = Object.create(null);
+  return C;
+})() as unknown as { new (): any };
+
+/**
  * Create an attachment Content-Disposition header.
  */
 export function create(filename?: string, options?: CreateOptions): string {
@@ -55,7 +64,7 @@ export function parse(string: string): ContentDisposition {
   // normalize type
   let index = match[0].length;
   const type = match[1].toLowerCase();
-  const parameters: Record<string, string> = Object.create(null);
+  const parameters: Record<string, string> = new NullObject();
 
   let key;
   const names = [];
@@ -227,7 +236,7 @@ function createparams(
     throw new TypeError('fallback must be ISO-8859-1 string');
   }
 
-  const params: Record<string, string> = {};
+  const params: Record<string, string> = new NullObject();
 
   // restrict to file base name
   const name = basename(filename);


### PR DESCRIPTION
One of the easiest optimizations to make, same as https://github.com/jshttp/content-type/pull/62.

Before:

```
 ✓ src/index.bench.ts > create 4928ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · create()          15,473,249.63  0.0000  0.6731  0.0001  0.0001  0.0001  0.0002  0.0002  ±0.48%  7736625
   · create(filename)   2,252,167.02  0.0002  1.6996  0.0004  0.0004  0.0010  0.0013  0.0218  ±1.48%  1126094

 ✓ src/index.bench.ts > parse 862ms
     name                   hz     min      max    mean     p75     p99    p995    p999     rme  samples
   · parse(header)  956,382.34  0.0007  20.8005  0.0010  0.0008  0.0023  0.0036  0.0398  ±8.62%   478192
```

After:

```
 ✓ src/index.bench.ts > create 4653ms
     name                         hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · create()          15,051,749.04  0.0000  1.0192  0.0001  0.0001  0.0002  0.0002  0.0002  ±0.71%  7525875
   · create(filename)   2,869,396.93  0.0002  0.0700  0.0003  0.0004  0.0004  0.0005  0.0006  ±0.13%  1434699

 ✓ src/index.bench.ts > parse 1065ms
     name                     hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse(header)  3,012,643.17  0.0002  8.9208  0.0003  0.0003  0.0004  0.0005  0.0010  ±3.51%  1506322
```