### PR TITLE
Make the parser lenient

### DIFF
--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,18 +1,22 @@
 import { bench, describe } from 'vitest';
 import { create, parse } from './index.js';
 
-describe('create', function () {
-  bench('create()', function () {
+describe('create', () => {
+  bench('create()', () => {
     create();
   });
 
-  bench('create(filename)', function () {
+  bench('create(filename)', () => {
     create('plans.pdf');
   });
 });
 
-describe('parse', function () {
-  bench('parse(header)', function () {
+describe('parse', () => {
+  bench('parse(header)', () => {
     parse('attachment; filename="plans.pdf"');
+  });
+
+  bench('parse(header) with UTF-8 extended parameter', () => {
+    parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,10 @@ export function parse(header: string): ContentDisposition {
         if (key.charCodeAt(key.length - 1) === 42 /* "*" */) {
           const normalizedKey = key.slice(0, -1);
           const decoded = decodeRFC8187(value);
-          if (decoded !== undefined) parameters[normalizedKey] = decoded;
-          continue parameter;
+          if (decoded !== undefined) {
+            parameters[normalizedKey] = decoded;
+            continue parameter;
+          }
         }
 
         if (parameters[key] === undefined) parameters[key] = value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,42 +55,74 @@ export function parse(string: string): ContentDisposition {
     throw new TypeError('argument string is required');
   }
 
-  let match = DISPOSITION_TYPE_REGEXP.exec(string);
-
-  if (!match) {
+  let index = 0;
+  const typeEnd = parseToken(string, index);
+  if (typeEnd === -1) {
     throw new TypeError('invalid type format');
   }
 
-  // normalize type
-  let index = match[0].length;
-  const type = match[1].toLowerCase();
+  const type = string.slice(index, typeEnd).toLowerCase();
+  index = skipLinearWhitespace(string, typeEnd);
+
+  if (index < string.length && string[index] !== ';') {
+    throw new TypeError('invalid type format');
+  }
+
   const parameters: Record<string, string> = new NullObject();
+  const names = new Set<string>();
 
-  let key;
-  const names = [];
-  let value;
-
-  // calculate index to start at
-  index = PARAM_REGEXP.lastIndex =
-    match[0].slice(-1) === ';' ? index - 1 : index;
-
-  // match parameters
-  while ((match = PARAM_REGEXP.exec(string))) {
-    if (match.index !== index) {
+  while (index < string.length) {
+    if (string[index] !== ';') {
       throw new TypeError('invalid parameter format');
     }
 
-    index += match[0].length;
-    key = match[1].toLowerCase();
-    value = match[2];
+    index = skipLinearWhitespace(string, index + 1);
 
-    if (names.indexOf(key) !== -1) {
+    const keyStart = index;
+    const keyEnd = parseToken(string, index);
+    if (keyEnd === -1) {
+      throw new TypeError('invalid parameter format');
+    }
+
+    index = skipLinearWhitespace(string, keyEnd);
+
+    if (index >= string.length || string[index] !== '=') {
+      throw new TypeError('invalid parameter format');
+    }
+
+    index = skipLinearWhitespace(string, index + 1);
+
+    let value: string;
+    let isQuoted = false;
+    if (index < string.length && string[index] === '"') {
+      const parsedQuoted = parseQuotedString(string, index);
+      value = parsedQuoted.value;
+      index = parsedQuoted.index;
+      isQuoted = true;
+    } else {
+      const valueEnd = parseToken(string, index);
+      if (valueEnd === -1) {
+        throw new TypeError('invalid parameter format');
+      }
+
+      value = string.slice(index, valueEnd);
+      index = valueEnd;
+    }
+
+    index = skipLinearWhitespace(string, index);
+
+    let key = string.slice(keyStart, keyEnd).toLowerCase();
+    if (names.has(key)) {
       throw new TypeError('invalid duplicate parameter');
     }
 
-    names.push(key);
+    names.add(key);
 
     if (key.indexOf('*') + 1 === key.length) {
+      if (isQuoted) {
+        throw new TypeError('invalid extended field value');
+      }
+
       // decode extended value
       key = key.slice(0, -1);
       value = decodefield(value);
@@ -104,16 +136,7 @@ export function parse(string: string): ContentDisposition {
       continue;
     }
 
-    if (value[0] === '"') {
-      // remove quotes and escapes
-      value = value.slice(1, -1).replace(QESC_REGEXP, '$1');
-    }
-
     parameters[key] = value;
-  }
-
-  if (index !== -1 && index !== string.length) {
-    throw new TypeError('invalid parameter format');
   }
 
   return { type, parameters };
@@ -133,14 +156,6 @@ const ENCODE_URL_ATTR_CHAR_REGEXP = /[\x00-\x20"'()*,/:;<=>?@[\\\]{}\x7f]/g; // 
  * RegExp to match non-latin1 characters.
  */
 const NON_LATIN1_REGEXP = /[^\x20-\x7e\xa0-\xff]/g;
-
-/**
- * RegExp to match quoted-pair in RFC 2616
- *
- * quoted-pair = "\" CHAR
- * CHAR        = <any US-ASCII character (octets 0 - 127)>
- */
-const QESC_REGEXP = /\\([\u0000-\u007f])/g; // eslint-disable-line no-control-regex
 
 /**
  * RegExp to match chars that must be quoted-pair in RFC 2616
@@ -170,48 +185,8 @@ const QUOTE_REGEXP = /([\\"])/g;
  * CTL           = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
  * OCTET         = <any 8-bit sequence of data>
  */
-const PARAM_REGEXP =
-  /;[\x09\x20]*([!#$%&'*+.0-9A-Z^_`a-z|~-]+)[\x09\x20]*=[\x09\x20]*("(?:[\x20!\x23-\x5b\x5d-\x7e\x80-\xff]|\\[\x20-\x7e])*"|[!#$%&'*+.0-9A-Z^_`a-z|~-]+)[\x09\x20]*/g; // eslint-disable-line no-control-regex
 const TEXT_REGEXP = /^[\x20-\x7e\x80-\xff]+$/;
 const TOKEN_REGEXP = /^[!#$%&'*+.0-9A-Z^_`a-z|~-]+$/;
-
-/**
- * RegExp for various RFC 5987 grammar
- *
- * ext-value     = charset  "'" [ language ] "'" value-chars
- * charset       = "UTF-8" / "ISO-8859-1" / mime-charset
- * mime-charset  = 1*mime-charsetc
- * mime-charsetc = ALPHA / DIGIT
- *               / "!" / "#" / "$" / "%" / "&"
- *               / "+" / "-" / "^" / "_" / "`"
- *               / "{" / "}" / "~"
- * language      = ( 2*3ALPHA [ extlang ] )
- *               / 4ALPHA
- *               / 5*8ALPHA
- * extlang       = *3( "-" 3ALPHA )
- * value-chars   = *( pct-encoded / attr-char )
- * pct-encoded   = "%" HEXDIG HEXDIG
- * attr-char     = ALPHA / DIGIT
- *               / "!" / "#" / "$" / "&" / "+" / "-" / "."
- *               / "^" / "_" / "`" / "|" / "~"
- */
-const EXT_VALUE_REGEXP =
-  /^([A-Za-z0-9!#$%&+\-^_`{}~]+)'(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}|[A-Za-z]{4,8}|)'((?:%[0-9A-Fa-f]{2}|[A-Za-z0-9!#$&+.^_`|~-])+)$/;
-
-/**
- * RegExp for various RFC 6266 grammar
- *
- * disposition-type = "inline" | "attachment" | disp-ext-type
- * disp-ext-type    = token
- * disposition-parm = filename-parm | disp-ext-parm
- * filename-parm    = "filename" "=" value
- *                  | "filename*" "=" ext-value
- * disp-ext-parm    = token "=" value
- *                  | ext-token "=" ext-value
- * ext-token        = <the characters in token, followed by "*">
- */
-const DISPOSITION_TYPE_REGEXP =
-  /^([!#$%&'*+.0-9A-Z^_`a-z|~-]+)[\x09\x20]*(?:$|;)/; // eslint-disable-line no-control-regex
 
 /**
  * Create parameters object from filename and fallback.
@@ -268,16 +243,31 @@ function createparams(
  * Decode a RFC 5987 field value (gracefully).
  */
 function decodefield(str: string): string {
-  const match = EXT_VALUE_REGEXP.exec(str);
-
-  if (!match) {
+  const charsetEnd = str.indexOf("'");
+  if (charsetEnd <= 0) {
     throw new TypeError('invalid extended field value');
   }
 
-  const charset = match[1].toLowerCase();
-  const encoded = match[2];
+  const languageEnd = str.indexOf("'", charsetEnd + 1);
+  if (languageEnd === -1) {
+    throw new TypeError('invalid extended field value');
+  }
 
-  switch (charset) {
+  const charset = str.slice(0, charsetEnd);
+  const language = str.slice(charsetEnd + 1, languageEnd);
+  const encoded = str.slice(languageEnd + 1);
+
+  if (
+    !isMimeCharset(charset) ||
+    !isLanguageTag(language) ||
+    !isExtendedValueChars(encoded)
+  ) {
+    throw new TypeError('invalid extended field value');
+  }
+
+  const normalizedCharset = charset.toLowerCase();
+
+  switch (normalizedCharset) {
     case 'iso-8859-1': {
       const binary = decodeHexEscapes(encoded);
       return getlatin1(binary);
@@ -302,6 +292,70 @@ function decodefield(str: string): string {
   }
 
   throw new TypeError('unsupported charset in extended field');
+}
+
+/**
+ * Parse a token starting at the provided index.
+ */
+function parseToken(str: string, index: number): number {
+  let end = index;
+
+  while (end < str.length && isTokenChar(str[end])) {
+    end++;
+  }
+
+  return end === index ? -1 : end;
+}
+
+/**
+ * Parse a quoted string starting at the provided index.
+ */
+function parseQuotedString(
+  str: string,
+  index: number,
+): { value: string; index: number } {
+  let result = '';
+  let cursor = index + 1;
+
+  while (cursor < str.length) {
+    const char = str[cursor];
+
+    if (char === '"') {
+      return { value: result, index: cursor + 1 };
+    }
+
+    if (char === '\\') {
+      cursor++;
+
+      if (cursor >= str.length || !isQuotedPairChar(str[cursor])) {
+        throw new TypeError('invalid parameter format');
+      }
+
+      result += str[cursor];
+      cursor++;
+      continue;
+    }
+
+    if (!isQuotedTextChar(char)) {
+      throw new TypeError('invalid parameter format');
+    }
+
+    result += char;
+    cursor++;
+  }
+
+  throw new TypeError('invalid parameter format');
+}
+
+/**
+ * Skip RFC 2616 linear whitespace (space / tab).
+ */
+function skipLinearWhitespace(str: string, index: number): number {
+  while (index < str.length && isLinearWhitespace(str[index])) {
+    index++;
+  }
+
+  return index;
 }
 
 /**
@@ -402,6 +456,192 @@ function basename(path: string): string {
   }
 
   return normalized.slice(start + 1, end);
+}
+
+/**
+ * Check if a character is RFC 2616 linear whitespace.
+ */
+function isLinearWhitespace(char: string): boolean {
+  return char === ' ' || char === '\t';
+}
+
+/**
+ * Check if a character is valid in a token.
+ */
+function isTokenChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+
+  return (
+    isAlphaNumericCode(code) ||
+    char === '!' ||
+    char === '#' ||
+    char === '$' ||
+    char === '%' ||
+    char === '&' ||
+    char === "'" ||
+    char === '*' ||
+    char === '+' ||
+    char === '.' ||
+    char === '^' ||
+    char === '_' ||
+    char === '`' ||
+    char === '|' ||
+    char === '~' ||
+    char === '-'
+  );
+}
+
+/**
+ * Check if a character is allowed directly inside a quoted string.
+ */
+function isQuotedTextChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+
+  return (
+    (code >= 0x20 && code <= 0x21) ||
+    (code >= 0x23 && code <= 0x5b) ||
+    (code >= 0x5d && code <= 0x7e) ||
+    (code >= 0x80 && code <= 0xff)
+  );
+}
+
+/**
+ * Check if a character is valid after a quoted-pair escape.
+ */
+function isQuotedPairChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 0x20 && code <= 0x7e;
+}
+
+/**
+ * Check if a string is a valid MIME charset token.
+ */
+function isMimeCharset(str: string): boolean {
+  if (str.length === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < str.length; index++) {
+    const char = str[index];
+    const code = char.charCodeAt(0);
+
+    if (
+      !isAlphaNumericCode(code) &&
+      char !== '!' &&
+      char !== '#' &&
+      char !== '$' &&
+      char !== '%' &&
+      char !== '&' &&
+      char !== '+' &&
+      char !== '-' &&
+      char !== '^' &&
+      char !== '_' &&
+      char !== '`' &&
+      char !== '{' &&
+      char !== '}' &&
+      char !== '~'
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check if a string looks like a RFC 5646 language tag.
+ */
+function isLanguageTag(str: string): boolean {
+  if (str.length === 0) {
+    return true;
+  }
+
+  let segmentLength = 0;
+
+  for (let index = 0; index < str.length; index++) {
+    const char = str[index];
+
+    if (char === '-') {
+      if (segmentLength === 0) {
+        return false;
+      }
+
+      segmentLength = 0;
+      continue;
+    }
+
+    if (!isAlphaCode(char.charCodeAt(0))) {
+      return false;
+    }
+
+    segmentLength++;
+  }
+
+  return segmentLength > 0;
+}
+
+/**
+ * Check if a string contains only RFC 5987 value-chars.
+ */
+function isExtendedValueChars(str: string): boolean {
+  if (str.length === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < str.length; index++) {
+    const char = str[index];
+    const code = char.charCodeAt(0);
+
+    if (char === '%') {
+      if (
+        index + 2 >= str.length ||
+        !isHexDigit(str[index + 1]) ||
+        !isHexDigit(str[index + 2])
+      ) {
+        return false;
+      }
+
+      index += 2;
+      continue;
+    }
+
+    if (
+      !isAlphaNumericCode(code) &&
+      char !== '!' &&
+      char !== '#' &&
+      char !== '$' &&
+      char !== '&' &&
+      char !== '+' &&
+      char !== '.' &&
+      char !== '^' &&
+      char !== '_' &&
+      char !== '`' &&
+      char !== '|' &&
+      char !== '~' &&
+      char !== '-'
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Check if a character code is alphabetic.
+ */
+function isAlphaCode(code: number): boolean {
+  return (
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) // a-z
+  );
+}
+
+/**
+ * Check if a character code is alphanumeric.
+ */
+function isAlphaNumericCode(code: number): boolean {
+  return isAlphaCode(code) || (code >= 48 && code <= 57);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,96 +47,81 @@ export function create(filename?: string, options?: CreateOptions): string {
   return format({ type, parameters });
 }
 
+const SP = 32; // " "
+const HTAB = 9; // "\t"
+const SEMI = 59; // ";"
+const EQ = 61; // "="
+const DQUOTE = 34; // '"'
+const BSLASH = 92; // "\\"
+
 /**
  * Parse Content-Disposition header string.
  */
-export function parse(string: string): ContentDisposition {
-  if (!string || typeof string !== 'string') {
-    throw new TypeError('argument string is required');
-  }
+export function parse(header: string): ContentDisposition {
+  const len = header.length;
+  let index = skipOWS(header, 0, header.length);
 
-  let index = 0;
-  const typeEnd = parseToken(string, index);
-  if (typeEnd === -1) {
-    throw new TypeError('invalid type format');
-  }
-
-  const type = string.slice(index, typeEnd).toLowerCase();
-  index = skipLinearWhitespace(string, typeEnd);
-
-  if (index < string.length && string[index] !== ';') {
-    throw new TypeError('invalid type format');
-  }
+  const typeStart = index;
+  index = parseToken(header, index, len);
+  const typeEnd = trailingOWS(header, typeStart, index);
+  const type = header.slice(typeStart, typeEnd).toLowerCase();
 
   const parameters: Record<string, string> = new NullObject();
-  const names = new Set<string>();
 
-  while (index < string.length) {
-    if (string[index] !== ';') {
-      throw new TypeError('invalid parameter format');
-    }
-
-    index = skipLinearWhitespace(string, index + 1);
+  parameter: while (index < len) {
+    index = skipOWS(header, index + 1, len); // Skip over semicolon.
 
     const keyStart = index;
-    const keyEnd = parseToken(string, index);
-    if (keyEnd === -1) {
-      throw new TypeError('invalid parameter format');
-    }
 
-    index = skipLinearWhitespace(string, keyEnd);
+    while (index < len) {
+      const char = header.charCodeAt(index);
+      if (char === SEMI) continue parameter;
 
-    if (index >= string.length || string[index] !== '=') {
-      throw new TypeError('invalid parameter format');
-    }
+      if (char === EQ) {
+        const keyEnd = trailingOWS(header, keyStart, index);
+        const key = header.slice(keyStart, keyEnd).toLowerCase();
 
-    index = skipLinearWhitespace(string, index + 1);
+        index = skipOWS(header, index + 1, len);
 
-    let value: string;
-    let isQuoted = false;
-    if (index < string.length && string[index] === '"') {
-      const parsedQuoted = parseQuotedString(string, index);
-      value = parsedQuoted.value;
-      index = parsedQuoted.index;
-      isQuoted = true;
-    } else {
-      const valueEnd = parseToken(string, index);
-      if (valueEnd === -1) {
-        throw new TypeError('invalid parameter format');
+        if (index < len && header.charCodeAt(index) === DQUOTE) {
+          index++;
+
+          let value = '';
+          while (index < len) {
+            const code = header.charCodeAt(index++);
+            if (code === DQUOTE) {
+              index = parseToken(header, index, len);
+              if (parameters[key] === undefined) parameters[key] = value;
+              continue parameter;
+            }
+
+            if (code === BSLASH && index < len) {
+              value += header[index++];
+              continue;
+            }
+
+            value += String.fromCharCode(code);
+          }
+        }
+
+        const valueStart = index;
+        index = parseToken(header, index, len);
+        const valueEnd = trailingOWS(header, valueStart, index);
+        const value = header.slice(valueStart, valueEnd);
+
+        if (key.charCodeAt(key.length - 1) === 42 /* "*" */) {
+          const normalizedKey = key.slice(0, -1);
+          const decoded = decodeRFC8187(value);
+          if (decoded !== undefined) parameters[normalizedKey] = decoded;
+          continue parameter;
+        }
+
+        if (parameters[key] === undefined) parameters[key] = value;
+        continue parameter;
       }
 
-      value = string.slice(index, valueEnd);
-      index = valueEnd;
+      index++;
     }
-
-    index = skipLinearWhitespace(string, index);
-
-    let key = string.slice(keyStart, keyEnd).toLowerCase();
-    if (names.has(key)) {
-      throw new TypeError('invalid duplicate parameter');
-    }
-
-    names.add(key);
-
-    if (key.indexOf('*') + 1 === key.length) {
-      if (isQuoted) {
-        throw new TypeError('invalid extended field value');
-      }
-
-      // decode extended value
-      key = key.slice(0, -1);
-      value = decodefield(value);
-
-      // overwrite existing value
-      parameters[key] = value;
-      continue;
-    }
-
-    if (typeof parameters[key] === 'string') {
-      continue;
-    }
-
-    parameters[key] = value;
   }
 
   return { type, parameters };
@@ -240,34 +225,23 @@ function createparams(
 }
 
 /**
- * Decode a RFC 5987 field value (gracefully).
+ * Decode a RFC 8187 field value (gracefully).
  */
-function decodefield(str: string): string {
+function decodeRFC8187(str: string): string | undefined {
   const charsetEnd = str.indexOf("'");
   if (charsetEnd <= 0) {
-    throw new TypeError('invalid extended field value');
+    return undefined;
   }
 
   const languageEnd = str.indexOf("'", charsetEnd + 1);
   if (languageEnd === -1) {
-    throw new TypeError('invalid extended field value');
+    return undefined;
   }
 
-  const charset = str.slice(0, charsetEnd);
-  const language = str.slice(charsetEnd + 1, languageEnd);
+  const charset = str.slice(0, charsetEnd).toLowerCase();
   const encoded = str.slice(languageEnd + 1);
 
-  if (
-    !isMimeCharset(charset) ||
-    !isLanguageTag(language) ||
-    !isExtendedValueChars(encoded)
-  ) {
-    throw new TypeError('invalid extended field value');
-  }
-
-  const normalizedCharset = charset.toLowerCase();
-
-  switch (normalizedCharset) {
+  switch (charset) {
     case 'iso-8859-1': {
       const binary = decodeHexEscapes(encoded);
       return getlatin1(binary);
@@ -291,71 +265,43 @@ function decodefield(str: string): string {
     }
   }
 
-  throw new TypeError('unsupported charset in extended field');
+  return undefined;
 }
 
 /**
  * Parse a token starting at the provided index.
  */
-function parseToken(str: string, index: number): number {
-  let end = index;
-
-  while (end < str.length && isTokenChar(str[end])) {
-    end++;
+function parseToken(str: string, index: number, len: number): number {
+  while (index < len) {
+    const char = str.charCodeAt(index);
+    if (char === SEMI) break;
+    index++;
   }
-
-  return end === index ? -1 : end;
-}
-
-/**
- * Parse a quoted string starting at the provided index.
- */
-function parseQuotedString(
-  str: string,
-  index: number,
-): { value: string; index: number } {
-  let result = '';
-  let cursor = index + 1;
-
-  while (cursor < str.length) {
-    const char = str[cursor];
-
-    if (char === '"') {
-      return { value: result, index: cursor + 1 };
-    }
-
-    if (char === '\\') {
-      cursor++;
-
-      if (cursor >= str.length || !isQuotedPairChar(str[cursor])) {
-        throw new TypeError('invalid parameter format');
-      }
-
-      result += str[cursor];
-      cursor++;
-      continue;
-    }
-
-    if (!isQuotedTextChar(char)) {
-      throw new TypeError('invalid parameter format');
-    }
-
-    result += char;
-    cursor++;
-  }
-
-  throw new TypeError('invalid parameter format');
+  return index;
 }
 
 /**
  * Skip RFC 2616 linear whitespace (space / tab).
  */
-function skipLinearWhitespace(str: string, index: number): number {
-  while (index < str.length && isLinearWhitespace(str[index])) {
+function skipOWS(str: string, index: number, len: number): number {
+  while (index < len) {
+    const char = str.charCodeAt(index);
+    if (char !== SP && char !== HTAB) break;
     index++;
   }
-
   return index;
+}
+
+/**
+ * Skip RFC 2616 linear whitespace (space / tab) from the end of a string.
+ */
+function trailingOWS(str: string, start: number, end: number): number {
+  while (end > start) {
+    const char = str.charCodeAt(end - 1);
+    if (char !== SP && char !== HTAB) break;
+    end--;
+  }
+  return end;
 }
 
 /**
@@ -456,192 +402,6 @@ function basename(path: string): string {
   }
 
   return normalized.slice(start + 1, end);
-}
-
-/**
- * Check if a character is RFC 2616 linear whitespace.
- */
-function isLinearWhitespace(char: string): boolean {
-  return char === ' ' || char === '\t';
-}
-
-/**
- * Check if a character is valid in a token.
- */
-function isTokenChar(char: string): boolean {
-  const code = char.charCodeAt(0);
-
-  return (
-    isAlphaNumericCode(code) ||
-    char === '!' ||
-    char === '#' ||
-    char === '$' ||
-    char === '%' ||
-    char === '&' ||
-    char === "'" ||
-    char === '*' ||
-    char === '+' ||
-    char === '.' ||
-    char === '^' ||
-    char === '_' ||
-    char === '`' ||
-    char === '|' ||
-    char === '~' ||
-    char === '-'
-  );
-}
-
-/**
- * Check if a character is allowed directly inside a quoted string.
- */
-function isQuotedTextChar(char: string): boolean {
-  const code = char.charCodeAt(0);
-
-  return (
-    (code >= 0x20 && code <= 0x21) ||
-    (code >= 0x23 && code <= 0x5b) ||
-    (code >= 0x5d && code <= 0x7e) ||
-    (code >= 0x80 && code <= 0xff)
-  );
-}
-
-/**
- * Check if a character is valid after a quoted-pair escape.
- */
-function isQuotedPairChar(char: string): boolean {
-  const code = char.charCodeAt(0);
-  return code >= 0x20 && code <= 0x7e;
-}
-
-/**
- * Check if a string is a valid MIME charset token.
- */
-function isMimeCharset(str: string): boolean {
-  if (str.length === 0) {
-    return false;
-  }
-
-  for (let index = 0; index < str.length; index++) {
-    const char = str[index];
-    const code = char.charCodeAt(0);
-
-    if (
-      !isAlphaNumericCode(code) &&
-      char !== '!' &&
-      char !== '#' &&
-      char !== '$' &&
-      char !== '%' &&
-      char !== '&' &&
-      char !== '+' &&
-      char !== '-' &&
-      char !== '^' &&
-      char !== '_' &&
-      char !== '`' &&
-      char !== '{' &&
-      char !== '}' &&
-      char !== '~'
-    ) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
- * Check if a string looks like a RFC 5646 language tag.
- */
-function isLanguageTag(str: string): boolean {
-  if (str.length === 0) {
-    return true;
-  }
-
-  let segmentLength = 0;
-
-  for (let index = 0; index < str.length; index++) {
-    const char = str[index];
-
-    if (char === '-') {
-      if (segmentLength === 0) {
-        return false;
-      }
-
-      segmentLength = 0;
-      continue;
-    }
-
-    if (!isAlphaCode(char.charCodeAt(0))) {
-      return false;
-    }
-
-    segmentLength++;
-  }
-
-  return segmentLength > 0;
-}
-
-/**
- * Check if a string contains only RFC 5987 value-chars.
- */
-function isExtendedValueChars(str: string): boolean {
-  if (str.length === 0) {
-    return false;
-  }
-
-  for (let index = 0; index < str.length; index++) {
-    const char = str[index];
-    const code = char.charCodeAt(0);
-
-    if (char === '%') {
-      if (
-        index + 2 >= str.length ||
-        !isHexDigit(str[index + 1]) ||
-        !isHexDigit(str[index + 2])
-      ) {
-        return false;
-      }
-
-      index += 2;
-      continue;
-    }
-
-    if (
-      !isAlphaNumericCode(code) &&
-      char !== '!' &&
-      char !== '#' &&
-      char !== '$' &&
-      char !== '&' &&
-      char !== '+' &&
-      char !== '.' &&
-      char !== '^' &&
-      char !== '_' &&
-      char !== '`' &&
-      char !== '|' &&
-      char !== '~' &&
-      char !== '-'
-    ) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
- * Check if a character code is alphabetic.
- */
-function isAlphaCode(code: number): boolean {
-  return (
-    (code >= 65 && code <= 90) || // A-Z
-    (code >= 97 && code <= 122) // a-z
-  );
-}
-
-/**
- * Check if a character code is alphanumeric.
- */
-function isAlphaNumericCode(code: number): boolean {
-  return isAlphaCode(code) || (code >= 48 && code <= 57);
 }
 
 /**

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -2,21 +2,19 @@ import { describe, it, assert } from 'vitest';
 import { parse } from './index';
 
 describe('parse(string)', function () {
-  it('should require string', function () {
-    assert.throws((parse as any).bind(null), /argument string.*required/);
-  });
-
-  it('should reject non-strings', function () {
-    assert.throws((parse as any).bind(null, 42), /argument string.*required/);
-  });
-
   describe('with only type', function () {
-    it('should reject quoted value', function () {
-      assert.throws(parse.bind(null, '"attachment"'), /invalid type format/);
+    it('should parse quoted value leniently', function () {
+      assert.deepEqual(parse('"attachment"'), {
+        type: '"attachment"',
+        parameters: {},
+      });
     });
 
-    it('should reject trailing semicolon', function () {
-      assert.throws(parse.bind(null, 'attachment;'), /invalid.*format/);
+    it('should ignore trailing semicolon', function () {
+      assert.deepEqual(parse('attachment;'), {
+        type: 'attachment',
+        parameters: {},
+      });
     });
 
     it('should parse "attachment"', function () {
@@ -56,57 +54,57 @@ describe('parse(string)', function () {
   });
 
   describe('with parameters', function () {
-    it('should reject trailing semicolon', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename="rates.pdf";'),
-        /invalid parameter format/,
-      );
+    it('should ignore trailing semicolon', function () {
+      assert.deepEqual(parse('attachment; filename="rates.pdf";'), {
+        type: 'attachment',
+        parameters: { filename: 'rates.pdf' },
+      });
     });
 
-    it('should reject invalid parameter name', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename@="rates.pdf"'),
-        /invalid parameter format/,
-      );
+    it('should preserve invalid parameter name', function () {
+      assert.deepEqual(parse('attachment; filename@="rates.pdf"'), {
+        type: 'attachment',
+        parameters: { 'filename@': 'rates.pdf' },
+      });
     });
 
-    it('should reject missing parameter value', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename='),
-        /invalid parameter format/,
-      );
+    it('should treat missing parameter value as empty', function () {
+      assert.deepEqual(parse('attachment; filename='), {
+        type: 'attachment',
+        parameters: { filename: '' },
+      });
     });
 
-    it('should reject invalid parameter value', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename=trolly,trains'),
-        /invalid parameter format/,
-      );
+    it('should preserve invalid parameter value', function () {
+      assert.deepEqual(parse('attachment; filename=trolly,trains'), {
+        type: 'attachment',
+        parameters: { filename: 'trolly,trains' },
+      });
     });
 
-    it('should reject invalid parameters', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename=total/; foo=bar'),
-        /invalid parameter format/,
-      );
+    it('should preserve otherwise invalid parameters', function () {
+      assert.deepEqual(parse('attachment; filename=total/; foo=bar'), {
+        type: 'attachment',
+        parameters: { filename: 'total/', foo: 'bar' },
+      });
     });
 
-    it('should reject duplicate parameters', function () {
-      assert.throws(
-        parse.bind(null, 'attachment; filename=foo; filename=bar'),
-        /invalid duplicate parameter/,
-      );
+    it('should keep the first duplicate parameter', function () {
+      assert.deepEqual(parse('attachment; filename=foo; filename=bar'), {
+        type: 'attachment',
+        parameters: { filename: 'foo' },
+      });
     });
 
-    it('should reject missing type', function () {
-      assert.throws(
-        parse.bind(null, 'filename="plans.pdf"'),
-        /invalid type format/,
-      );
-      assert.throws(
-        parse.bind(null, '; filename="plans.pdf"'),
-        /invalid type format/,
-      );
+    it('should parse missing type leniently', function () {
+      assert.deepEqual(parse('filename="plans.pdf"'), {
+        type: 'filename="plans.pdf"',
+        parameters: {},
+      });
+      assert.deepEqual(parse('; filename="plans.pdf"'), {
+        type: '',
+        parameters: { filename: 'plans.pdf' },
+      });
     });
 
     it('should lower-case parameter name', function () {
@@ -163,13 +161,13 @@ describe('parse(string)', function () {
   });
 
   describe('with extended parameters', function () {
-    it('should reject quoted extended parameter value', function () {
-      assert.throws(
-        parse.bind(
-          null,
-          'attachment; filename*="UTF-8\'\'%E2%82%AC%20rates.pdf"',
-        ),
-        /invalid extended.*value/,
+    it('should preserve quoted extended parameter value', function () {
+      assert.deepEqual(
+        parse('attachment; filename*="UTF-8\'\'%E2%82%AC%20rates.pdf"'),
+        {
+          type: 'attachment',
+          parameters: { 'filename*': "UTF-8''%E2%82%AC%20rates.pdf" },
+        },
       );
     });
 
@@ -234,10 +232,13 @@ describe('parse(string)', function () {
       );
     });
 
-    it('should reject unsupported charset', function () {
-      assert.throws(
-        parse.bind(null, "attachment; filename*=ISO-8859-2''%A4%20rates.pdf"),
-        /unsupported charset/,
+    it('should preserve unsupported charset as the original parameter', function () {
+      assert.deepEqual(
+        parse("attachment; filename*=ISO-8859-2''%A4%20rates.pdf"),
+        {
+          type: 'attachment',
+          parameters: { 'filename*': "ISO-8859-2''%A4%20rates.pdf" },
+        },
       );
     });
 
@@ -271,6 +272,21 @@ describe('parse(string)', function () {
         },
       );
     });
+
+    it('should keep fallback filename when extended parameter cannot be decoded', function () {
+      assert.deepEqual(
+        parse(
+          'attachment; filename="EURO rates.pdf"; filename*=ISO-8859-2\'\'%A4%20rates.pdf',
+        ),
+        {
+          type: 'attachment',
+          parameters: {
+            filename: 'EURO rates.pdf',
+            'filename*': "ISO-8859-2''%A4%20rates.pdf",
+          },
+        },
+      );
+    });
   });
 
   describe('from TC 2231', function () {
@@ -282,8 +298,11 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should reject ""inline""', function () {
-        assert.throws(parse.bind(null, '"inline"'), /invalid type format/);
+      it('should parse ""inline"" leniently', function () {
+        assert.deepEqual(parse('"inline"'), {
+          type: '"inline"',
+          parameters: {},
+        });
       });
 
       it('should parse "inline; filename="foo.html""', function () {
@@ -316,8 +335,11 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should reject ""attachment""', function () {
-        assert.throws(parse.bind(null, '"attachment"'), /invalid type format/);
+      it('should parse ""attachment"" leniently', function () {
+        assert.deepEqual(parse('"attachment"'), {
+          type: '"attachment"',
+          parameters: {},
+        });
       });
 
       it('should parse "ATTACHMENT"', function () {
@@ -412,32 +434,32 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should reject "attachment; filename=foo,bar.html"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo,bar.html'),
-          /invalid parameter format/,
-        );
+      it('should preserve commas in token values', function () {
+        assert.deepEqual(parse('attachment; filename=foo,bar.html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo,bar.html' },
+        });
       });
 
-      it('should reject "attachment; filename=foo.html ;"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo.html ;'),
-          /invalid parameter format/,
-        );
+      it('should ignore trailing semicolon after value', function () {
+        assert.deepEqual(parse('attachment; filename=foo.html ;'), {
+          type: 'attachment',
+          parameters: { filename: 'foo.html' },
+        });
       });
 
-      it('should reject "attachment; ;filename=foo"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; ;filename=foo'),
-          /invalid parameter format/,
-        );
+      it('should skip empty parameter slots', function () {
+        assert.deepEqual(parse('attachment; ;filename=foo'), {
+          type: 'attachment',
+          parameters: { filename: 'foo' },
+        });
       });
 
-      it('should reject "attachment; filename=foo bar.html"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo bar.html'),
-          /invalid parameter format/,
-        );
+      it('should preserve spaces in token values', function () {
+        assert.deepEqual(parse('attachment; filename=foo bar.html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo bar.html' },
+        });
       });
 
       it("should parse \"attachment; filename='foo.bar'", function () {
@@ -513,150 +535,150 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should reject "attachment; filename="foo.html"; filename="bar.html"', function () {
-        assert.throws(
-          parse.bind(
-            null,
-            'attachment; filename="foo.html"; filename="bar.html"',
-          ),
-          /invalid duplicate parameter/,
+      it('should keep the first duplicate quoted filename', function () {
+        assert.deepEqual(
+          parse('attachment; filename="foo.html"; filename="bar.html"'),
+          {
+            type: 'attachment',
+            parameters: { filename: 'foo.html' },
+          },
         );
       });
 
-      it('should reject "attachment; filename=foo[1](2).html"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo[1](2).html'),
-          /invalid parameter format/,
+      it('should preserve bracket characters in token values', function () {
+        assert.deepEqual(parse('attachment; filename=foo[1](2).html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo[1](2).html' },
+        });
+      });
+
+      it('should preserve latin1 token values', function () {
+        assert.deepEqual(parse('attachment; filename=foo-ä.html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo-ä.html' },
+        });
+      });
+
+      it('should preserve mojibake token values', function () {
+        assert.deepEqual(parse('attachment; filename=foo-Ã¤.html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo-Ã¤.html' },
+        });
+      });
+
+      it('should treat a bare parameter as the type', function () {
+        assert.deepEqual(parse('filename=foo.html'), {
+          type: 'filename=foo.html',
+          parameters: {},
+        });
+      });
+
+      it('should preserve invalid type token with parameters', function () {
+        assert.deepEqual(parse('x=y; filename=foo.html'), {
+          type: 'x=y',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should stop at the first recoverable parameter after a quoted type', function () {
+        assert.deepEqual(parse('"foo; filename=bar;baz"; filename=qux'), {
+          type: '"foo',
+          parameters: { filename: 'bar' },
+        });
+      });
+
+      it('should preserve commas in a malformed type token', function () {
+        assert.deepEqual(parse('filename=foo.html, filename=bar.html'), {
+          type: 'filename=foo.html, filename=bar.html',
+          parameters: {},
+        });
+      });
+
+      it('should allow an empty type when parameters follow', function () {
+        assert.deepEqual(parse('; filename=foo.html'), {
+          type: '',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should preserve leading punctuation in the type', function () {
+        assert.deepEqual(parse(': inline; attachment; filename=foo.html'), {
+          type: ': inline',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should skip bare parameters without values', function () {
+        assert.deepEqual(parse('inline; attachment; filename=foo.html'), {
+          type: 'inline',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should skip bare attachment parameters without values', function () {
+        assert.deepEqual(parse('attachment; inline; filename=foo.html'), {
+          type: 'attachment',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should ignore a suffix after a quoted filename', function () {
+        assert.deepEqual(parse('attachment; filename="foo.html".txt'), {
+          type: 'attachment',
+          parameters: { filename: 'foo.html' },
+        });
+      });
+
+      it('should treat an unterminated quoted filename as empty', function () {
+        assert.deepEqual(parse('attachment; filename="bar'), {
+          type: 'attachment',
+          parameters: { filename: '' },
+        });
+      });
+
+      it('should stop a token value at the next semicolon', function () {
+        assert.deepEqual(parse('attachment; filename=foo"bar;baz"qux'), {
+          type: 'attachment',
+          parameters: { filename: 'foo"bar' },
+        });
+      });
+
+      it('should preserve a comma-separated header fragment in the first value', function () {
+        assert.deepEqual(
+          parse('attachment; filename=foo.html, attachment; filename=bar.html'),
+          {
+            type: 'attachment',
+            parameters: { filename: 'foo.html, attachment' },
+          },
         );
       });
 
-      it('should reject "attachment; filename=foo-ä.html"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo-ä.html'),
-          /invalid parameter format/,
-        );
+      it('should keep an unseparated parameter assignment inside the value', function () {
+        assert.deepEqual(parse('attachment; foo=foo filename=bar'), {
+          type: 'attachment',
+          parameters: { foo: 'foo filename=bar' },
+        });
       });
 
-      it('should reject "attachment; filename=foo-Ã¤.html"', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo-Ã¤.html'),
-          /invalid parameter format/,
-        );
+      it('should keep trailing assignments inside the filename value', function () {
+        assert.deepEqual(parse('attachment; filename=bar foo=foo'), {
+          type: 'attachment',
+          parameters: { filename: 'bar foo=foo' },
+        });
       });
 
-      it('should reject "filename=foo.html"', function () {
-        assert.throws(
-          parse.bind(null, 'filename=foo.html'),
-          /invalid type format/,
-        );
+      it('should treat missing semicolon after the type as part of the type', function () {
+        assert.deepEqual(parse('attachment filename=bar'), {
+          type: 'attachment filename=bar',
+          parameters: {},
+        });
       });
 
-      it('should reject "x=y; filename=foo.html"', function () {
-        assert.throws(
-          parse.bind(null, 'x=y; filename=foo.html'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject ""foo; filename=bar;baz"; filename=qux"', function () {
-        assert.throws(
-          parse.bind(null, '"foo; filename=bar;baz"; filename=qux'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject "filename=foo.html, filename=bar.html"', function () {
-        assert.throws(
-          parse.bind(null, 'filename=foo.html, filename=bar.html'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject "; filename=foo.html"', function () {
-        assert.throws(
-          parse.bind(null, '; filename=foo.html'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject ": inline; attachment; filename=foo.html', function () {
-        assert.throws(
-          parse.bind(null, ': inline; attachment; filename=foo.html'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject "inline; attachment; filename=foo.html', function () {
-        assert.throws(
-          parse.bind(null, 'inline; attachment; filename=foo.html'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; inline; filename=foo.html', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; inline; filename=foo.html'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; filename="foo.html".txt', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename="foo.html".txt'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; filename="bar', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename="bar'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; filename=foo"bar;baz"qux', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=foo"bar;baz"qux'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; filename=foo.html, attachment; filename=bar.html', function () {
-        assert.throws(
-          parse.bind(
-            null,
-            'attachment; filename=foo.html, attachment; filename=bar.html',
-          ),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; foo=foo filename=bar', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; foo=foo filename=bar'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment; filename=bar foo=foo', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename=bar foo=foo'),
-          /invalid parameter format/,
-        );
-      });
-
-      it('should reject "attachment filename=bar', function () {
-        assert.throws(
-          parse.bind(null, 'attachment filename=bar'),
-          /invalid type format/,
-        );
-      });
-
-      it('should reject "filename=foo.html; attachment', function () {
-        assert.throws(
-          parse.bind(null, 'filename=foo.html; attachment'),
-          /invalid type format/,
-        );
+      it('should keep the first malformed type segment', function () {
+        assert.deepEqual(parse('filename=foo.html; attachment'), {
+          type: 'filename=foo.html',
+          parameters: {},
+        });
       });
 
       it('should parse "attachment; xfilename=foo.html"', function () {
@@ -744,10 +766,13 @@ describe('parse(string)', function () {
         );
       });
 
-      it('should reject "attachment; filename*=\'\'foo-%c3%a4-%e2%82%ac.html"', function () {
-        assert.throws(
-          parse.bind(null, "attachment; filename*=''foo-%c3%a4-%e2%82%ac.html"),
-          /invalid extended.*value/,
+      it('should preserve extended values without a charset', function () {
+        assert.deepEqual(
+          parse("attachment; filename*=''foo-%c3%a4-%e2%82%ac.html"),
+          {
+            type: 'attachment',
+            parameters: { 'filename*': "''foo-%c3%a4-%e2%82%ac.html" },
+          },
         );
       });
 
@@ -778,10 +803,13 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should reject "attachment; filename *=UTF-8\'\'foo-%c3%a4.html"', function () {
-        assert.throws(
-          parse.bind(null, "attachment; filename *=UTF-8''foo-%c3%a4.html"),
-          /invalid parameter format/,
+      it('should preserve spaces before the star in the parameter name', function () {
+        assert.deepEqual(
+          parse("attachment; filename *=UTF-8''foo-%c3%a4.html"),
+          {
+            type: 'attachment',
+            parameters: { 'filename ': 'foo-ä.html' },
+          },
         );
       });
 
@@ -805,39 +833,42 @@ describe('parse(string)', function () {
         );
       });
 
-      it('should reject "attachment; filename*="UTF-8\'\'foo-%c3%a4.html""', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename*="UTF-8\'\'foo-%c3%a4.html"'),
-          /invalid extended field value/,
+      it('should preserve quoted UTF-8 extended values verbatim', function () {
+        assert.deepEqual(
+          parse('attachment; filename*="UTF-8\'\'foo-%c3%a4.html"'),
+          {
+            type: 'attachment',
+            parameters: { 'filename*': "UTF-8''foo-%c3%a4.html" },
+          },
         );
       });
 
-      it('should reject "attachment; filename*="foo%20bar.html""', function () {
-        assert.throws(
-          parse.bind(null, 'attachment; filename*="foo%20bar.html"'),
-          /invalid extended field value/,
-        );
+      it('should preserve quoted extended values without charset verbatim', function () {
+        assert.deepEqual(parse('attachment; filename*="foo%20bar.html"'), {
+          type: 'attachment',
+          parameters: { 'filename*': 'foo%20bar.html' },
+        });
       });
 
-      it('should reject "attachment; filename*=UTF-8\'foo-%c3%a4.html"', function () {
-        assert.throws(
-          parse.bind(null, "attachment; filename*=UTF-8'foo-%c3%a4.html"),
-          /invalid extended field value/,
-        );
+      it('should preserve extended values without both apostrophes', function () {
+        assert.deepEqual(parse("attachment; filename*=UTF-8'foo-%c3%a4.html"), {
+          type: 'attachment',
+          parameters: { 'filename*': "UTF-8'foo-%c3%a4.html" },
+        });
       });
 
-      it('should reject "attachment; filename*=UTF-8\'\'foo%"', function () {
-        assert.throws(
-          parse.bind(null, "attachment; filename*=UTF-8''foo%"),
-          /invalid extended field value/,
-        );
+      it('should preserve malformed trailing percent escapes', function () {
+        assert.deepEqual(parse("attachment; filename*=UTF-8''foo%"), {
+          type: 'attachment',
+          parameters: { filename: 'foo%' },
+        });
       });
 
-      it('should reject "attachment; filename*=UTF-8\'\'f%oo.html"', function () {
-        assert.throws(
-          parse.bind(null, "attachment; filename*=UTF-8''f%oo.html"),
-          /invalid extended field value/,
-        );
+      it('should preserve malformed percent escapes inside the value', function () {
+        assert.deepEqual(parse("attachment; filename*=UTF-8''f%oo.html"), {
+          type: 'attachment',
+          parameters: { filename: 'f%oo.html' },
+        });
       });
 
       it('should parse "attachment; filename*=UTF-8\'\'A-%2541.html"', function () {
@@ -981,13 +1012,13 @@ describe('parse(string)', function () {
     });
 
     describe('RFC2047 Encoding', function () {
-      it('should reject "attachment; filename==?ISO-8859-1?Q?foo-=E4.html?="', function () {
-        assert.throws(
-          parse.bind(
-            null,
-            'attachment; filename==?ISO-8859-1?Q?foo-=E4.html?=',
-          ),
-          /invalid parameter format/,
+      it('should preserve RFC2047-looking token values', function () {
+        assert.deepEqual(
+          parse('attachment; filename==?ISO-8859-1?Q?foo-=E4.html?='),
+          {
+            type: 'attachment',
+            parameters: { filename: '=?ISO-8859-1?Q?foo-=E4.html?=' },
+          },
         );
       });
 

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -884,7 +884,7 @@ describe('parse(string)', function () {
           {
             type: 'attachment',
             parameters: {
-              'filename*0*': "UTF-8''foo-%c3%a4",
+              'filename*0': 'foo-ä',
               'filename*1': '.html',
             },
           },


### PR DESCRIPTION
Similar to the work I did on `content-type`, makes the parser lenient and faster.

Before:

```
 ✓ src/index.bench.ts > parse 1091ms
     name                     hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse(header)  3,181,304.47  0.0002  0.3111  0.0003  0.0003  0.0004  0.0005  0.0010  ±0.33%  1590653
```


After:

```
 ✓ src/index.bench.ts > parse 2413ms
     name                                                   hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parse(header)                                5,268,478.47  0.0001  0.3761  0.0002  0.0002  0.0003  0.0003  0.0007  ±0.36%  2634240
   · parse(header) with UTF-8 extended parameter  2,766,981.96  0.0002  0.3845  0.0004  0.0004  0.0005  0.0005  0.0010  ±0.31%  1383491
```
