### PR TITLE
Fix stateful NON_LATIN1_REGEXP in createparams

### DIFF
--- a/src/create.spec.ts
+++ b/src/create.spec.ts
@@ -307,3 +307,16 @@ describe('create(filename, options)', function () {
     });
   });
 });
+
+describe('create() regex state bug', function () {
+  it('should still throw on second call with non-ISO-8859-1 fallback', function () {
+    assert.throws(
+      create.bind(null, 'file.pdf', { fallback: '€ rates.pdf' }),
+      /fallback.*iso-8859-1/i,
+    );
+    assert.throws(
+      create.bind(null, 'file.pdf', { fallback: '€' }),
+      /fallback.*iso-8859-1/i,
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,8 +232,11 @@ function createparams(
     throw new TypeError('fallback must be a string or boolean');
   }
 
-  if (typeof fallback === 'string' && NON_LATIN1_REGEXP.test(fallback)) {
-    throw new TypeError('fallback must be ISO-8859-1 string');
+  if (typeof fallback === 'string') {
+    NON_LATIN1_REGEXP.lastIndex = 0;
+    if (NON_LATIN1_REGEXP.test(fallback)) {
+      throw new TypeError('fallback must be ISO-8859-1 string');
+    }
   }
 
   const params: Record<string, string> = new NullObject();


### PR DESCRIPTION
The module-level NON_LATIN1_REGEXP has the /g flag, so calling `.test(fallback)` leaves `lastIndex` at the match position. A subsequent `create()` call with a non-ISO-8859-1 fallback would resume matching from that stale index, could miss earlier non-latin1 characters, and silently bypass the "fallback must be ISO-8859-1 string" validation - producing a Content-Disposition with non-latin1 bytes in filename=.

Reset `lastIndex` to 0 before the `.test` call to keep the validation deterministic across invocations.