### PR TITLE
Expose format API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install content-disposition
 ## API
 
 ```js
-import { create, parse } from 'content-disposition';
+import { create, parse, format } from 'content-disposition';
 ```
 
 ### create(filename, options)
@@ -62,26 +62,40 @@ and this set as the fallback field, even though they are both ISO-8859-1.
 Specifies the disposition type, defaults to `"attachment"`. This can also be
 `"inline"`, or any other value (all values except inline are treated like
 `attachment`, but can convey additional information if both parties agree to
-it). The type is normalized to lower-case.
+it).
 
 ### parse(string)
 
 ```js
-const disposition = contentDisposition.parse(
+const disposition = parse(
   'attachment; filename="EURO rates.txt"; filename*=UTF-8\'\'%e2%82%ac%20rates.txt',
 );
 ```
 
 Parse a `Content-Disposition` header string. This automatically handles extended
 ("Unicode") parameters by decoding them and providing them under the standard
-parameter name. This will return an object with the following properties (examples
-are shown for the string `'attachment; filename="EURO rates.txt"; filename*=UTF-8\'\'%e2%82%ac%20rates.txt'`):
+parameter name. This will return an object with the following properties:
 
 - `type`: The disposition type (always lower case). Example: `'attachment'`
 
 - `parameters`: An object of the parameters in the disposition (name of parameter
   always lower case and extended versions replace non-extended versions). Example:
   `{filename: "€ rates.txt"}`
+
+### format(obj)
+
+```js
+const disposition = format({
+  type: 'attachment',
+  parameters: {
+    filename: '€ rates.txt',
+  },
+});
+```
+
+Formats an object to a `Content-Disposition` header string. This automatically
+handles extended ("Unicode") parameters and returns a string. Example:
+`'attachment; filename*=UTF-8''%E2%82%AC%20rates.txt'`
 
 ## Examples
 

--- a/src/create.spec.ts
+++ b/src/create.spec.ts
@@ -165,6 +165,13 @@ describe('create(filename, options)', function () {
         );
       });
 
+      it('should not generate fallback for Unicode filename', function () {
+        assert.strictEqual(
+          create('планы.pdf', { fallback: false }),
+          "attachment; filename*=UTF-8''%D0%BF%D0%BB%D0%B0%D0%BD%D1%8B.pdf",
+        );
+      });
+
       it('should keep ISO-8859-1 filename', function () {
         assert.strictEqual(
           create('£ rates.pdf', { fallback: false }),

--- a/src/create.spec.ts
+++ b/src/create.spec.ts
@@ -135,7 +135,7 @@ describe('create(filename)', function () {
     it('should keep a simple filename', function () {
       assert.strictEqual(
         create('the%20plans.pdf'),
-        'attachment; filename=the%20plans.pdf',
+        "attachment; filename=the%20plans.pdf; filename*=UTF-8''the%2520plans.pdf",
       );
     });
 

--- a/src/create.spec.ts
+++ b/src/create.spec.ts
@@ -8,83 +8,76 @@ describe('create()', function () {
 });
 
 describe('create(filename)', function () {
-  it('should require a string', function () {
-    assert.throws(create.bind(null, 42 as any), /filename.*string/);
-  });
-
   it('should create a header with file name', function () {
-    assert.strictEqual(create('plans.pdf'), 'attachment; filename="plans.pdf"');
+    assert.strictEqual(create('plans.pdf'), 'attachment; filename=plans.pdf');
   });
 
-  it('should use the basename of a posix path', function () {
+  it('should preserve a posix path', function () {
     assert.strictEqual(
       create('/path/to/plans.pdf'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="/path/to/plans.pdf"',
     );
   });
 
-  it('should use the basename of a windows path', function () {
+  it('should preserve a windows path', function () {
     assert.strictEqual(
       create('\\path\\to\\plans.pdf'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="\\\\path\\\\to\\\\plans.pdf"',
     );
   });
 
-  it('should use the basename of a windows path with drive letter', function () {
+  it('should preserve a windows path with drive letter', function () {
     assert.strictEqual(
       create('C:\\path\\to\\plans.pdf'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="C:\\\\path\\\\to\\\\plans.pdf"',
     );
   });
 
-  it('should use the basename of a posix path with trailing slash', function () {
+  it('should preserve a posix path with trailing slash', function () {
     assert.strictEqual(
       create('/path/to/plans.pdf/'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="/path/to/plans.pdf/"',
     );
   });
 
-  it('should use the basename of a windows path with trailing slash', function () {
+  it('should preserve a windows path with trailing slash', function () {
     assert.strictEqual(
       create('\\path\\to\\plans.pdf\\'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="\\\\path\\\\to\\\\plans.pdf\\\\"',
     );
   });
 
-  it('should use the basename of a windows path with drive letter and trailing slash', function () {
+  it('should preserve a windows path with drive letter and trailing slash', function () {
     assert.strictEqual(
       create('C:\\path\\to\\plans.pdf\\'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="C:\\\\path\\\\to\\\\plans.pdf\\\\"',
     );
   });
 
-  it('should use the basename of a posix path with trailing slashes', function () {
+  it('should preserve a posix path with trailing slashes', function () {
     assert.strictEqual(
       create('/path/to/plans.pdf///'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="/path/to/plans.pdf///"',
     );
   });
 
-  it('should use the basename of a windows path with trailing slashes', function () {
+  it('should preserve a windows path with trailing slashes', function () {
     assert.strictEqual(
       create('\\path\\to\\plans.pdf\\\\\\'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="\\\\path\\\\to\\\\plans.pdf\\\\\\\\\\\\"',
     );
   });
 
-  it('should use the basename of a windows path with drive letter and trailing slashes', function () {
+  it('should preserve a windows path with drive letter and trailing slashes', function () {
     assert.strictEqual(
       create('C:\\path\\to\\plans.pdf\\\\\\'),
-      'attachment; filename="plans.pdf"',
+      'attachment; filename="C:\\\\path\\\\to\\\\plans.pdf\\\\\\\\\\\\"',
     );
   });
 
   describe('when "filename" is US-ASCII', function () {
     it('should only include filename parameter', function () {
-      assert.strictEqual(
-        create('plans.pdf'),
-        'attachment; filename="plans.pdf"',
-      );
+      assert.strictEqual(create('plans.pdf'), 'attachment; filename=plans.pdf');
     });
 
     it('should escape quotes', function () {
@@ -139,10 +132,10 @@ describe('create(filename)', function () {
   });
 
   describe('when "filename" contains hex escape', function () {
-    it('should include filename* parameter', function () {
+    it('should keep a simple filename', function () {
       assert.strictEqual(
         create('the%20plans.pdf'),
-        'attachment; filename="the%20plans.pdf"; filename*=UTF-8\'\'the%2520plans.pdf',
+        'attachment; filename=the%20plans.pdf',
       );
     });
 
@@ -157,13 +150,6 @@ describe('create(filename)', function () {
 
 describe('create(filename, options)', function () {
   describe('with "fallback" option', function () {
-    it('should require a string or Boolean', function () {
-      assert.throws(
-        create.bind(null, 'plans.pdf', { fallback: 42 } as any),
-        /fallback.*string/,
-      );
-    });
-
     it('should default to true', function () {
       assert.strictEqual(
         create('€ rates.pdf'),
@@ -232,34 +218,34 @@ describe('create(filename, options)', function () {
       it('should do nothing if equal to filename', function () {
         assert.strictEqual(
           create('plans.pdf', { fallback: 'plans.pdf' }),
-          'attachment; filename="plans.pdf"',
+          'attachment; filename=plans.pdf',
         );
       });
 
-      it('should use the basename of a posix path', function () {
+      it('should preserve a posix fallback path', function () {
         assert.strictEqual(
           create('€ rates.pdf', {
             fallback: '/path/to/EURO rates.pdf',
           }),
-          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
+          'attachment; filename="/path/to/EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
         );
       });
 
-      it('should use the basename of a windows path', function () {
+      it('should preserve a windows fallback path', function () {
         assert.strictEqual(
           create('€ rates.pdf', {
             fallback: '\\path\\to\\EURO rates.pdf',
           }),
-          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
+          'attachment; filename="\\\\path\\\\to\\\\EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
         );
       });
 
-      it('should use the basename of a windows path with drive letter', function () {
+      it('should preserve a windows fallback path with drive letter', function () {
         assert.strictEqual(
           create('€ rates.pdf', {
             fallback: 'C:\\path\\to\\EURO rates.pdf',
           }),
-          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
+          'attachment; filename="C:\\\\path\\\\to\\\\EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
         );
       });
 
@@ -277,17 +263,10 @@ describe('create(filename, options)', function () {
       assert.strictEqual(create(), 'attachment');
     });
 
-    it('should require a string', function () {
-      assert.throws(
-        create.bind(null, undefined, { type: 42 } as any),
-        /invalid type/,
-      );
-    });
-
     it('should require a valid type', function () {
       assert.throws(
         create.bind(null, undefined, { type: 'invalid;type' }),
-        /invalid type/,
+        /Invalid type: invalid;type/,
       );
     });
 
@@ -298,12 +277,12 @@ describe('create(filename, options)', function () {
     it('should create a header with inline type & filename', function () {
       assert.strictEqual(
         create('plans.pdf', { type: 'inline' }),
-        'inline; filename="plans.pdf"',
+        'inline; filename=plans.pdf',
       );
     });
 
-    it('should normalize type', function () {
-      assert.strictEqual(create(undefined, { type: 'INLINE' }), 'inline');
+    it('should preserve type casing', function () {
+      assert.strictEqual(create(undefined, { type: 'INLINE' }), 'INLINE');
     });
   });
 });

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -56,6 +56,16 @@ describe('format(obj)', function () {
     );
   });
 
+  it('should maintain case sensitivity', function () {
+    assert.strictEqual(
+      format({
+        type: 'Attachment',
+        parameters: { Filename: 'Plans.pdf' },
+      }),
+      'Attachment; Filename=Plans.pdf',
+    );
+  });
+
   it('should throw for missing type', function () {
     assert.throws(format.bind(null, {}), /invalid type/i);
   });

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -1,0 +1,76 @@
+import { assert, describe, it } from 'vitest';
+import { format } from './index';
+
+describe('format(obj)', function () {
+  it('should format a header with only type', function () {
+    assert.strictEqual(format({ type: 'attachment' }), 'attachment');
+  });
+
+  it('should format token parameters without quotes', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { filename: 'plans.pdf', foo: 'bar' },
+      }),
+      'attachment; filename=plans.pdf; foo=bar',
+    );
+  });
+
+  it('should quote text parameter values', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { filename: 'the plans.pdf' },
+      }),
+      'attachment; filename="the plans.pdf"',
+    );
+  });
+
+  it('should escape quotes and backslashes in quoted values', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { filename: 'the "plans" \\.pdf' },
+      }),
+      'attachment; filename="the \\"plans\\" \\\\.pdf"',
+    );
+  });
+
+  it('should quote ISO-8859-1 parameter values', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { filename: '£ rates.pdf' },
+      }),
+      'attachment; filename="£ rates.pdf"',
+    );
+  });
+
+  it('should encode Unicode parameter values as extended fields', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { filename: '€ rates.pdf' },
+      }),
+      "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+    );
+  });
+
+  it('should throw for missing type', function () {
+    assert.throws(format.bind(null, {}), /invalid type/i);
+  });
+
+  it('should throw for invalid disposition type', function () {
+    assert.throws(format.bind(null, { type: 'invalid type' }), /invalid type/i);
+  });
+
+  it('should throw for invalid parameter name', function () {
+    assert.throws(
+      format.bind(null, {
+        type: 'attachment',
+        parameters: { 'file name': 'plans.pdf' },
+      }),
+      /invalid parameter name/i,
+    );
+  });
+});

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest';
-import { create, parse } from './index.js';
+import { create, decodeExtended, encodeExtended, parse } from './index.js';
 
 describe('create', () => {
   bench('create()', () => {
@@ -18,5 +18,25 @@ describe('parse', () => {
 
   bench('parse(header) with UTF-8 extended parameter', () => {
     parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
+  });
+});
+
+describe('decodeExtended', () => {
+  bench('decodeExtended(value)', () => {
+    decodeExtended("UTF-8''%E2%82%AC%20rates.pdf");
+  });
+
+  bench('decodeExtended(value) with invalid encoding', () => {
+    decodeExtended("UTF-8''%E2%82%AC%20rates.pdf%ZZ");
+  });
+
+  bench('decodeExtended(value) with latin1 encoding', () => {
+    decodeExtended("ISO-8859-1''%E2%82%AC%20rates.pdf");
+  });
+});
+
+describe('encodeExtended', () => {
+  bench('encodeExtended(filename)', () => {
+    encodeExtended('€ rates.pdf');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const NullObject = /* @__PURE__ */ (() => {
  */
 export function create(filename?: string, options?: CreateOptions): string {
   const type = options?.type || 'attachment';
-  const parameters = createparams(filename, options?.fallback);
+  const parameters = createParameters(filename, options?.fallback);
 
   return format({ type, parameters });
 }
@@ -111,7 +111,7 @@ export function parse(header: string): ContentDisposition {
 
         if (key.charCodeAt(key.length - 1) === 42 /* "*" */) {
           const normalizedKey = key.slice(0, -1);
-          const decoded = decodeRFC8187(value);
+          const decoded = decodeExtended(value);
           if (decoded !== undefined) {
             parameters[normalizedKey] = decoded;
             continue parameter;
@@ -142,7 +142,7 @@ const NON_LATIN1_REGEXP = /[^\x20-\x7e\xa0-\xff]/g;
 /**
  * RegExp to match chars that must be quoted-pair in RFC 2616
  */
-const QUOTE_REGEXP = /([\\"])/g;
+const QUOTE_REGEXP = /[\\"]/g;
 
 /**
  * RegExp for various RFC 2616 grammar
@@ -173,58 +173,38 @@ const TOKEN_REGEXP = /^[!#$%&'*+.0-9A-Z^_`a-z|~-]+$/;
 /**
  * Create parameters object from filename and fallback.
  */
-function createparams(
+function createParameters(
   filename?: string,
   fallback: string | boolean = true,
 ): Record<string, string> | undefined {
-  if (filename === undefined) {
-    return;
+  if (filename === undefined) return;
+
+  // Just use `filename`.
+  if (fallback === false) return { filename };
+
+  if (typeof fallback === 'string') {
+    if (!TEXT_REGEXP.test(fallback)) {
+      throw new TypeError('Fallback must be valid ISO-8859-1: ' + fallback);
+    }
+
+    if (fallback === filename) return { filename };
+    return { filename: fallback, 'filename*': encodeExtended(filename) };
   }
 
-  if (typeof filename !== 'string') {
-    throw new TypeError('filename must be a string');
-  }
+  // Use `filename` when it's simple.
+  const isSimpleFilename = TEXT_REGEXP.test(filename);
+  if (isSimpleFilename) return { filename };
 
-  if (typeof fallback !== 'string' && typeof fallback !== 'boolean') {
-    throw new TypeError('fallback must be a string or boolean');
-  }
-
-  if (typeof fallback === 'string' && NON_LATIN1_REGEXP.test(fallback)) {
-    throw new TypeError('fallback must be ISO-8859-1 string');
-  }
-
-  const params: Record<string, string> = new NullObject();
-
-  // restrict to file base name
-  const name = basename(filename);
-
-  // determine if name is suitable for quoted string
-  const isQuotedString = TEXT_REGEXP.test(name);
-
-  // generate fallback name
-  const fallbackName =
-    typeof fallback !== 'string'
-      ? fallback && getlatin1(name)
-      : basename(fallback);
-  const hasFallback = typeof fallbackName === 'string' && fallbackName !== name;
-
-  // set extended filename parameter
-  if (hasFallback || !isQuotedString || hasHexEscape(name)) {
-    params['filename*'] = name;
-  }
-
-  // set filename parameter
-  if (isQuotedString || hasFallback) {
-    params.filename = hasFallback ? fallbackName : name;
-  }
-
-  return params;
+  return {
+    filename: getlatin1(filename),
+    'filename*': encodeExtended(filename),
+  };
 }
 
 /**
  * Decode a RFC 8187 field value (gracefully).
  */
-function decodeRFC8187(str: string): string | undefined {
+export function decodeExtended(str: string): string | undefined {
   const charsetEnd = str.indexOf("'");
   if (charsetEnd <= 0) {
     return undefined;
@@ -301,39 +281,38 @@ function trailingOWS(str: string, start: number, end: number): number {
 /**
  * Format object to Content-Disposition header.
  */
-function format(obj: Partial<ContentDisposition>): string {
-  if (!obj || typeof obj !== 'object') {
-    throw new TypeError('argument obj is required');
+export function format(obj: Partial<ContentDisposition>): string {
+  const { type, parameters } = obj;
+
+  if (!type || !TOKEN_REGEXP.test(type)) {
+    throw new TypeError('Invalid type: ' + type);
   }
 
-  if (
-    !obj.type ||
-    typeof obj.type !== 'string' ||
-    !TOKEN_REGEXP.test(obj.type)
-  ) {
-    throw new TypeError('invalid type');
-  }
+  let result = type;
 
-  // start with normalized type
-  let string = obj.type.toLowerCase();
+  if (parameters) {
+    for (const param of Object.keys(parameters)) {
+      const value = parameters[param];
 
-  // append parameters
-  if (obj.parameters && typeof obj.parameters === 'object') {
-    const params = Object.keys(obj.parameters).sort();
+      if (!TOKEN_REGEXP.test(param)) {
+        throw new TypeError('Invalid parameter name: ' + param);
+      }
 
-    for (let i = 0; i < params.length; i++) {
-      const param = params[i];
+      if (TOKEN_REGEXP.test(value)) {
+        result += '; ' + param + '=' + value;
+        continue;
+      }
 
-      const val =
-        param.slice(-1) === '*'
-          ? ustring(obj.parameters[param])
-          : qstring(obj.parameters[param]);
+      if (TEXT_REGEXP.test(value)) {
+        result += '; ' + param + '=' + qstring(value);
+        continue;
+      }
 
-      string += `; ${param}=${val}`;
+      result += '; ' + param + '*=' + encodeExtended(value);
     }
   }
 
-  return string;
+  return result;
 }
 
 /**
@@ -354,48 +333,20 @@ function pencode(char: string): string {
 /**
  * Quote a string for HTTP.
  */
-function qstring(val: unknown): string {
-  const str = String(val);
-
-  return '"' + str.replace(QUOTE_REGEXP, '\\$1') + '"';
+function qstring(str: string): string {
+  return '"' + str.replace(QUOTE_REGEXP, '\\$&') + '"';
 }
 
 /**
  * Encode a Unicode string for HTTP (RFC 5987).
  */
-function ustring(val: unknown): string {
-  const str = String(val);
-
-  // percent encode as UTF-8
+export function encodeExtended(str: string): string {
   const encoded = encodeURIComponent(str).replace(
     ENCODE_URL_ATTR_CHAR_REGEXP,
     pencode,
   );
 
   return "UTF-8''" + encoded;
-}
-
-/**
- * Return the last portion of a path
- */
-function basename(path: string): string {
-  const normalized = path.replaceAll('\\', '/');
-
-  let end = normalized.length;
-  while (end > 0 && normalized[end - 1] === '/') {
-    end--;
-  }
-
-  if (end === 0) {
-    return '';
-  }
-
-  let start = end - 1;
-  while (start >= 0 && normalized[start] !== '/') {
-    start--;
-  }
-
-  return normalized.slice(start + 1, end);
 }
 
 /**
@@ -408,25 +359,6 @@ function isHexDigit(char: string): boolean {
     (code >= 65 && code <= 70) || // A-F
     (code >= 97 && code <= 102) // a-f
   );
-}
-
-/**
- * Check if a string contains percent encoding escapes.
- */
-function hasHexEscape(str: string): boolean {
-  const maxIndex = str.length - 3;
-  let lastIndex = -1;
-
-  while (
-    (lastIndex = str.indexOf('%', lastIndex + 1)) !== -1 &&
-    lastIndex <= maxIndex
-  ) {
-    if (isHexDigit(str[lastIndex + 1]) && isHexDigit(str[lastIndex + 2])) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,9 +184,6 @@ function createParameters(
 ): Record<string, string> | undefined {
   if (filename === undefined) return;
 
-  // Just use `filename`.
-  if (fallback === false) return { filename };
-
   if (typeof fallback === 'string') {
     if (!TEXT_REGEXP.test(fallback)) {
       throw new TypeError('Fallback must be valid ISO-8859-1: ' + fallback);
@@ -199,6 +196,10 @@ function createParameters(
   // Use `filename` when possible, otherwise use `filename*`.
   if (TEXT_REGEXP.test(filename) && !INVALID_FILENAME_REGEXP.test(filename)) {
     return { filename };
+  }
+
+  if (fallback === false) {
+    return { 'filename*': encodeExtended(filename) };
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,11 @@ const NON_LATIN1_REGEXP = /[^\x20-\x7e\xa0-\xff]/g;
 const QUOTE_REGEXP = /[\\"]/g;
 
 /**
+ * Match chars that can't be used in the filename for compatibility.
+ */
+const INVALID_FILENAME_REGEXP = /%[0-9A-Fa-f]{2}/;
+
+/**
  * RegExp for various RFC 2616 grammar
  *
  * parameter     = token "=" ( token | quoted-string )
@@ -191,9 +196,10 @@ function createParameters(
     return { filename: fallback, 'filename*': encodeExtended(filename) };
   }
 
-  // Use `filename` when it's simple.
-  const isSimpleFilename = TEXT_REGEXP.test(filename);
-  if (isSimpleFilename) return { filename };
+  // Use `filename` when possible, otherwise use `filename*`.
+  if (TEXT_REGEXP.test(filename) && !INVALID_FILENAME_REGEXP.test(filename)) {
+    return { filename };
+  }
 
   return {
     filename: getlatin1(filename),


### PR DESCRIPTION
Updates and exposes the format API directly. Accepts the same shape object produced by `parse`, with the same automatic encoding of UTF-8.

Removes the `basename` behavior to instead allow whatever the user has provided. The specification doesn't say anything about disallowing it to be generated, but that it should be handled properly when parsed.