### PR TITLE
Allow extended parsing to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ parse('form-data; name="file"; filename="the %22plans%22.pdf"', {
 });
 ```
 
+##### extended
+
+Parse RFC 5987 extended header parameters automatically when decoding
+parameters, defaults to `true`.
+
 ### format(obj, options)
 
 ```js
@@ -126,6 +131,11 @@ format(
   { multipart: true },
 );
 ```
+
+##### extended
+
+Encode Unicode parameter values using RFC 5987 extended header parameters,
+e.g. `filename*=`, defaults to `true`.
 
 ## Examples
 

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -66,6 +66,48 @@ describe('format(obj)', function () {
     );
   });
 
+  describe('with "extended" option', function () {
+    it('should still format ISO-8859-1 parameter values when false', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'attachment',
+            parameters: { filename: '£ rates.pdf' },
+          },
+          { extended: false },
+        ),
+        'attachment; filename="£ rates.pdf"',
+      );
+    });
+
+    it('should preserve pre-encoded extended parameter values when false', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'attachment',
+            parameters: { 'filename*': "UTF-8''%E2%82%AC%20rates.pdf" },
+          },
+          { extended: false },
+        ),
+        "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+      );
+    });
+
+    it('should throw for Unicode parameter values when false', function () {
+      assert.throws(
+        format.bind(
+          null,
+          {
+            type: 'attachment',
+            parameters: { filename: '€ rates.pdf' },
+          },
+          { extended: false },
+        ),
+        /invalid parameter value/i,
+      );
+    });
+  });
+
   it('should throw for missing type', function () {
     assert.throws(format.bind(null, {}), /invalid type/i);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,15 @@ export interface ContentDisposition {
   parameters: Record<string, string>;
 }
 
+/**
+ * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
+ */
+const NullObject = /* @__PURE__ */ (() => {
+  const C = function () {};
+  C.prototype = Object.create(null);
+  return C;
+})() as unknown as { new (): any };
+
 export interface CreateOptions {
   /**
    * Content-Disposition type, defaults to "attachment"
@@ -28,31 +37,6 @@ export interface CreateOptions {
   fallback?: string | boolean;
 }
 
-export interface ParseOptions {
-  /**
-   * Parse parameters as sent by browsers in `multipart/form-data`.
-   * @default false
-   */
-  multipart?: boolean;
-}
-
-export interface FormatOptions {
-  /**
-   * Format parameters as sent by browsers in `multipart/form-data`.
-   * @default false
-   */
-  multipart?: boolean;
-}
-
-/**
- * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
- */
-const NullObject = /* @__PURE__ */ (() => {
-  const C = function () {};
-  C.prototype = Object.create(null);
-  return C;
-})() as unknown as { new (): any };
-
 /**
  * Create an attachment Content-Disposition header.
  */
@@ -60,7 +44,7 @@ export function create(filename?: string, options?: CreateOptions): string {
   const type = options?.type || 'attachment';
   const parameters = createParameters(filename, options?.fallback);
 
-  return format({ type, parameters });
+  return format({ type, parameters }, { extended: false });
 }
 
 const SP = 32; // " "
@@ -69,6 +53,20 @@ const SEMI = 59; // ";"
 const EQ = 61; // "="
 const DQUOTE = 34; // '"'
 const BSLASH = 92; // "\\"
+const ASTERISK = 42; // "*"
+
+export interface ParseOptions {
+  /**
+   * Whether to decode RFC 8187 encoded parameters.
+   * @default true
+   */
+  extended?: boolean;
+  /**
+   * Parse parameters as sent by browsers in `multipart/form-data`.
+   * @default false
+   */
+  multipart?: boolean;
+}
 
 /**
  * Parse Content-Disposition header string.
@@ -79,6 +77,7 @@ export function parse(
 ): ContentDisposition {
   const len = header.length;
   const multipart = options?.multipart === true;
+  const extended = options?.extended !== false;
   let index = skipOWS(header, 0, header.length);
 
   const typeStart = index;
@@ -170,7 +169,7 @@ export function parse(
         const valueEnd = trailingOWS(header, valueStart, index);
         const value = header.slice(valueStart, valueEnd);
 
-        if (key.charCodeAt(key.length - 1) === 42 /* "*" */) {
+        if (extended && key.charCodeAt(key.length - 1) === ASTERISK) {
           const normalizedKey = key.slice(0, -1);
           const decoded = decodeExtended(value);
           if (decoded !== undefined) {
@@ -350,6 +349,20 @@ function trailingOWS(str: string, start: number, end: number): number {
   return end;
 }
 
+export interface FormatOptions {
+  /**
+   * Whether to use extended parameter encoding for non-ISO-8859-1 strings.
+   * If false, an error will be thrown when formatting such strings.
+   * @default true
+   */
+  extended?: boolean;
+  /**
+   * Format parameters as sent by browsers in `multipart/form-data`.
+   * @default false
+   */
+  multipart?: boolean;
+}
+
 /**
  * Format object to Content-Disposition header.
  */
@@ -359,6 +372,7 @@ export function format(
 ): string {
   const { type, parameters } = obj;
   const multipart = options?.multipart === true;
+  const extended = options?.extended !== false;
 
   if (!type || !TOKEN_REGEXP.test(type)) {
     throw new TypeError('Invalid type: ' + type);
@@ -387,6 +401,10 @@ export function format(
       if (TEXT_REGEXP.test(value)) {
         result += '; ' + param + '=' + qstring(value);
         continue;
+      }
+
+      if (!extended) {
+        throw new TypeError('Invalid parameter value: ' + value);
       }
 
       result += '; ' + param + '*=' + encodeExtended(value);

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -228,6 +228,13 @@ describe('parse(string)', function () {
       );
     });
 
+    it('should parse iso-8859-1 extended parameter value containing ASCII only', function () {
+      assert.deepEqual(parse("attachment; filename*=ISO-8859-1''ABC.pdf"), {
+        type: 'attachment',
+        parameters: { filename: 'ABC.pdf' },
+      });
+    });
+
     it('should not be case-sensitive for charset', function () {
       assert.deepEqual(
         parse("attachment; filename*=utf-8''%E2%82%AC%20rates.pdf"),
@@ -292,6 +299,36 @@ describe('parse(string)', function () {
           },
         },
       );
+    });
+
+    describe('when "extended" option is false', function () {
+      it('should preserve extended parameter value without decoding', function () {
+        assert.deepEqual(
+          parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf", {
+            extended: false,
+          }),
+          {
+            type: 'attachment',
+            parameters: { 'filename*': "UTF-8''%E2%82%AC%20rates.pdf" },
+          },
+        );
+      });
+
+      it('should preserve both fallback and extended parameter values', function () {
+        assert.deepEqual(
+          parse(
+            'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
+            { extended: false },
+          ),
+          {
+            type: 'attachment',
+            parameters: {
+              filename: 'EURO rates.pdf',
+              'filename*': "UTF-8''%E2%82%AC%20rates.pdf",
+            },
+          },
+        );
+      });
     });
   });
 
@@ -1060,6 +1097,18 @@ describe('parse(string, options)', function () {
       );
     });
 
+    it('should decode uppercase line feed escapes', function () {
+      assert.deepEqual(
+        parse('form-data; name="upload"; filename="foo%0Abar%0D.txt"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'upload', filename: 'foo\nbar\r.txt' },
+        },
+      );
+    });
+
     it('should handle incomplete percent escapes', function () {
       assert.deepEqual(
         parse('form-data; name="upload"; filename="foo%2"', {
@@ -1101,7 +1150,7 @@ describe('parse(string, options)', function () {
         parse(
           format({
             type: 'form-data',
-            parameters: { name: 'foo\nbar', filename: 'foo\rbar.txt' },
+            parameters: { name: 'foo\nbar', filename: '"foo\rbar".txt' },
           }),
           {
             multipart: true,
@@ -1109,7 +1158,7 @@ describe('parse(string, options)', function () {
         ),
         {
           type: 'form-data',
-          parameters: { name: 'foo\nbar', filename: 'foo\rbar.txt' },
+          parameters: { name: 'foo\nbar', filename: '"foo\rbar".txt' },
         },
       );
     });


### PR DESCRIPTION
Expands upon the format API https://github.com/jshttp/content-disposition/pull/129 with an `extended` option that can be used to disable the `*=` feature. I expect to add a couple more flags around parsing behavior to handle multipart and the other MIME encoding format so this is a safe place to introduce our first option. I don't expect it to be used much, but it may be useful for MIME or other contexts that support UTF-8 headers and therefore don't need the extended behavior.