### PR TITLE
Add HTML multipart behavior compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Specifies the disposition type, defaults to `"attachment"`. This can also be
 `attachment`, but can convey additional information if both parties agree to
 it).
 
-### parse(string)
+### parse(string, options)
 
 ```js
 const disposition = parse(
@@ -82,7 +82,19 @@ parameter name. This will return an object with the following properties:
   always lower case and extended versions replace non-extended versions). Example:
   `{filename: "€ rates.txt"}`
 
-### format(obj)
+#### Options
+
+##### multipart
+
+Parse parameters using browser `multipart/form-data` behavior.
+
+```js
+parse('form-data; name="file"; filename="the %22plans%22.pdf"', {
+  multipart: true,
+});
+```
+
+### format(obj, options)
 
 ```js
 const disposition = format({
@@ -96,6 +108,24 @@ const disposition = format({
 Formats an object to a `Content-Disposition` header string. This automatically
 handles extended ("Unicode") parameters and returns a string. Example:
 `'attachment; filename*=UTF-8''%E2%82%AC%20rates.txt'`
+
+#### Options
+
+##### multipart
+
+Format parameters using browser `multipart/form-data` behavior. This quotes
+parameter values, escapes `"` as `%22`, and writes Unicode values directly
+instead of using extended parameters.
+
+```js
+format(
+  {
+    type: 'form-data',
+    parameters: { name: 'file', filename: '€ rates.txt' },
+  },
+  { multipart: true },
+);
+```
 
 ## Examples
 

--- a/demo/server.js
+++ b/demo/server.js
@@ -97,7 +97,7 @@ async function inspectUpload(req) {
     const dispositionHeader = part.headers['content-disposition'];
     if (!dispositionHeader) continue;
 
-    const disposition = parse(dispositionHeader);
+    const disposition = parse(dispositionHeader, { multipart: true });
     const name = disposition.parameters.name || '';
     const filename = disposition.parameters.filename;
 

--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -84,3 +84,59 @@ describe('format(obj)', function () {
     );
   });
 });
+
+describe('format(obj, options)', function () {
+  describe('with "multipart" option', function () {
+    it('should quote token parameter values', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'form-data',
+            parameters: { name: 'file', filename: 'plans.pdf' },
+          },
+          { multipart: true },
+        ),
+        'form-data; name="file"; filename="plans.pdf"',
+      );
+    });
+
+    it('should percent-escape quotes and newlines', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'form-data',
+            parameters: { name: 'a\r\nb', filename: 'the "plans".pdf' },
+          },
+          { multipart: true },
+        ),
+        'form-data; name="a%0D%0Ab"; filename="the %22plans%22.pdf"',
+      );
+    });
+
+    it('should not use extended parameters for Unicode values', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'form-data',
+            parameters: { name: 'upload', filename: '€ rates.pdf' },
+          },
+          { multipart: true },
+        ),
+        'form-data; name="upload"; filename="€ rates.pdf"',
+      );
+    });
+
+    it('should preserve backslashes without quoted-pair escaping', function () {
+      assert.strictEqual(
+        format(
+          {
+            type: 'form-data',
+            parameters: { filename: '\\plans.pdf' },
+          },
+          { multipart: true },
+        ),
+        'form-data; filename="\\plans.pdf"',
+      );
+    });
+  });
+});

--- a/src/index.bench.ts
+++ b/src/index.bench.ts
@@ -19,6 +19,10 @@ describe('parse', () => {
   bench('parse(header) with UTF-8 extended parameter', () => {
     parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
   });
+
+  bench('parse(header) with multipart enabled', () => {
+    parse('attachment; filename="the %22plans%22.pdf"', { multipart: true });
+  });
 });
 
 describe('decodeExtended', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -431,14 +431,9 @@ function qmultipart(str: string): string {
  * Escape a multipart/form-data string character.
  */
 function multipartEscape(char: string): string {
-  switch (char) {
-    case '\n':
-      return '%0A';
-    case '\r':
-      return '%0D';
-    default:
-      return '%22';
-  }
+  if (char === '\n') return '%0A';
+  if (char === '\r') return '%0D';
+  return '%22';
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,22 @@ export interface CreateOptions {
   fallback?: string | boolean;
 }
 
+export interface ParseOptions {
+  /**
+   * Parse parameters as sent by browsers in `multipart/form-data`.
+   * @default false
+   */
+  multipart?: boolean;
+}
+
+export interface FormatOptions {
+  /**
+   * Format parameters as sent by browsers in `multipart/form-data`.
+   * @default false
+   */
+  multipart?: boolean;
+}
+
 /**
  * Null object perf optimization. Faster than `Object.create(null)` and `{ __proto__: null }`.
  */
@@ -57,8 +73,12 @@ const BSLASH = 92; // "\\"
 /**
  * Parse Content-Disposition header string.
  */
-export function parse(header: string): ContentDisposition {
+export function parse(
+  header: string,
+  options?: ParseOptions,
+): ContentDisposition {
   const len = header.length;
+  const multipart = options?.multipart === true;
   let index = skipOWS(header, 0, header.length);
 
   const typeStart = index;
@@ -87,21 +107,62 @@ export function parse(header: string): ContentDisposition {
           index++;
 
           let value = '';
-          while (index < len) {
-            const code = header.charCodeAt(index++);
-            if (code === DQUOTE) {
-              index = parseToken(header, index, len);
-              if (parameters[key] === undefined) parameters[key] = value;
-              continue parameter;
-            }
 
-            if (code === BSLASH && index < len) {
-              value += header[index++];
-              continue;
-            }
+          if (multipart) {
+            while (index < len) {
+              const code = header.charCodeAt(index++);
+              if (code === DQUOTE) {
+                index = parseToken(header, index, len);
+                if (parameters[key] === undefined) parameters[key] = value;
+                break;
+              }
 
-            value += String.fromCharCode(code);
+              if (code === /* % */ 37 && index + 1 < len) {
+                const code2 = header.charCodeAt(index);
+                const code3 = header.charCodeAt(index + 1);
+
+                if (code2 === 50 /* "2" */ && code3 === 50 /* "2" */) {
+                  value += '"';
+                  index += 2;
+                  continue;
+                }
+
+                if (code2 === 48 /* "0" */) {
+                  if (code3 === 100 /* "d" */ || code3 === 68 /* "D" */) {
+                    value += '\r';
+                    index += 2;
+                    continue;
+                  }
+
+                  if (code3 === 97 /* "a" */ || code3 === 65 /* "A" */) {
+                    value += '\n';
+                    index += 2;
+                    continue;
+                  }
+                }
+              }
+
+              value += String.fromCharCode(code);
+            }
+          } else {
+            while (index < len) {
+              const code = header.charCodeAt(index++);
+              if (code === DQUOTE) {
+                index = parseToken(header, index, len);
+                if (parameters[key] === undefined) parameters[key] = value;
+                break;
+              }
+
+              if (code === BSLASH && index < len) {
+                value += header[index++];
+                continue;
+              }
+
+              value += String.fromCharCode(code);
+            }
           }
+
+          continue parameter;
         }
 
         const valueStart = index;
@@ -292,8 +353,12 @@ function trailingOWS(str: string, start: number, end: number): number {
 /**
  * Format object to Content-Disposition header.
  */
-export function format(obj: Partial<ContentDisposition>): string {
+export function format(
+  obj: Partial<ContentDisposition>,
+  options?: FormatOptions,
+): string {
   const { type, parameters } = obj;
+  const multipart = options?.multipart === true;
 
   if (!type || !TOKEN_REGEXP.test(type)) {
     throw new TypeError('Invalid type: ' + type);
@@ -307,6 +372,11 @@ export function format(obj: Partial<ContentDisposition>): string {
 
       if (!TOKEN_REGEXP.test(param)) {
         throw new TypeError('Invalid parameter name: ' + param);
+      }
+
+      if (multipart) {
+        result += '; ' + param + '=' + qmultipart(value);
+        continue;
       }
 
       if (TOKEN_REGEXP.test(value)) {
@@ -346,6 +416,29 @@ function pencode(char: string): string {
  */
 function qstring(str: string): string {
   return '"' + str.replace(QUOTE_REGEXP, '\\$&') + '"';
+}
+
+/**
+ * Quote a string for multipart/form-data.
+ *
+ * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data
+ */
+function qmultipart(str: string): string {
+  return '"' + str.replace(/[\n\r"]/g, multipartEscape) + '"';
+}
+
+/**
+ * Escape a multipart/form-data string character.
+ */
+function multipartEscape(char: string): string {
+  switch (char) {
+    case '\n':
+      return '%0A';
+    case '\r':
+      return '%0D';
+    default:
+      return '%22';
+  }
 }
 
 /**

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert } from 'vitest';
-import { parse } from './index';
+import { parse, format } from './index';
 
 describe('parse(string)', function () {
   describe('with only type', function () {
@@ -635,10 +635,10 @@ describe('parse(string)', function () {
         });
       });
 
-      it('should treat an unterminated quoted filename as empty', function () {
+      it('should treat an unterminated quoted as omitted', function () {
         assert.deepEqual(parse('attachment; filename="bar'), {
           type: 'attachment',
-          parameters: { filename: '' },
+          parameters: {},
         });
       });
 
@@ -1030,6 +1030,88 @@ describe('parse(string)', function () {
           },
         );
       });
+    });
+  });
+});
+
+describe('parse(string, options)', function () {
+  describe('with "multipart" option', function () {
+    it('should parse browser multipart field names and filenames', function () {
+      assert.deepEqual(
+        parse('form-data; name="upload"; filename="the %22plans%22.pdf"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'upload', filename: 'the "plans".pdf' },
+        },
+      );
+    });
+
+    it('should decode new line characters', function () {
+      assert.deepEqual(
+        parse('form-data; name="upload"; filename="foo%0abar%0d.txt"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'upload', filename: 'foo\nbar\r.txt' },
+        },
+      );
+    });
+
+    it('should handle incomplete percent escapes', function () {
+      assert.deepEqual(
+        parse('form-data; name="upload"; filename="foo%2"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'upload', filename: 'foo%2' },
+        },
+      );
+    });
+
+    it('should preserve Unicode values', function () {
+      assert.deepEqual(
+        parse('form-data; name="upload"; filename="€ rates.pdf"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'upload', filename: '€ rates.pdf' },
+        },
+      );
+    });
+
+    it('should not decode other percent escapes', function () {
+      assert.deepEqual(
+        parse('form-data; name="foo%20bar"; filename="foo%41bar.txt"', {
+          multipart: true,
+        }),
+        {
+          type: 'form-data',
+          parameters: { name: 'foo%20bar', filename: 'foo%41bar.txt' },
+        },
+      );
+    });
+
+    it('should roundtrip percent escapes', function () {
+      assert.deepEqual(
+        parse(
+          format({
+            type: 'form-data',
+            parameters: { name: 'foo\nbar', filename: 'foo\rbar.txt' },
+          }),
+          {
+            multipart: true,
+          },
+        ),
+        {
+          type: 'form-data',
+          parameters: { name: 'foo\nbar', filename: 'foo\rbar.txt' },
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
Builds upon the demo parser/server PR.

Adds multipart behavior support based on the HTML spec. Will be useful for handling browser uploads. In `format`, it does not encode as `filename*` (matching browser behavior) but on server it does decode `filename*` since it would need to match more than browser behavior, such as better formed uploads.