### PR TITLE
Reject invalid percent-encoding in ISO-8859-1 ext-value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,22 +481,27 @@ function isHexDigit(char: string): boolean {
 /**
  * Decode hex escapes in a string (e.g., %20 -> space)
  */
-function decodeHexEscapes(str: string): string {
+function decodeHexEscapes(str: string): string | undefined {
   const firstEscape = str.indexOf('%');
   if (firstEscape === -1) return str;
 
   let result = str.slice(0, firstEscape);
   for (let idx = firstEscape; idx < str.length; idx++) {
-    if (
-      str[idx] === '%' &&
-      idx + 2 < str.length &&
-      isHexDigit(str[idx + 1]) &&
-      isHexDigit(str[idx + 2])
-    ) {
-      result += String.fromCharCode(
-        Number.parseInt(str[idx + 1] + str[idx + 2], 16),
-      );
-      idx += 2;
+    if (str[idx] === '%') {
+      if (
+        idx + 2 < str.length &&
+        isHexDigit(str[idx + 1]) &&
+        isHexDigit(str[idx + 2])
+      ) {
+        result += String.fromCharCode(
+          Number.parseInt(str[idx + 1] + str[idx + 2], 16),
+        );
+        idx += 2;
+      } else {
+        // malformed percent-encoding: reject per RFC 8187 3.2.1, matching the
+        // UTF-8 path, so the unprocessable ext-value is ignored
+        return undefined;
+      }
     } else {
       result += str[idx];
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,20 +488,19 @@ function decodeHexEscapes(str: string): string | undefined {
   let result = str.slice(0, firstEscape);
   for (let idx = firstEscape; idx < str.length; idx++) {
     if (str[idx] === '%') {
+      // Reject malformed percent encoding, matches UTF-8 behavior.
       if (
-        idx + 2 < str.length &&
-        isHexDigit(str[idx + 1]) &&
-        isHexDigit(str[idx + 2])
+        idx + 2 >= str.length ||
+        !isHexDigit(str[idx + 2]) ||
+        !isHexDigit(str[idx + 1])
       ) {
-        result += String.fromCharCode(
-          Number.parseInt(str[idx + 1] + str[idx + 2], 16),
-        );
-        idx += 2;
-      } else {
-        // malformed percent-encoding: reject per RFC 8187 3.2.1, matching the
-        // UTF-8 path, so the unprocessable ext-value is ignored
-        return undefined;
+        return;
       }
+
+      result += String.fromCharCode(
+        Number.parseInt(str[idx + 1] + str[idx + 2], 16),
+      );
+      idx += 2;
     } else {
       result += str[idx];
     }

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -253,6 +253,31 @@ describe('parse(string)', function () {
       });
     });
 
+    it('should ignore invalid percent-encodings in ISO-8859-1 extended parameter value', function () {
+      assert.deepEqual(
+        parse("attachment; filename*=ISO-8859-1''%A3%2rates.pdf"),
+        {
+          type: 'attachment',
+          parameters: {
+            'filename*': "ISO-8859-1''%A3%2rates.pdf",
+          },
+        },
+      );
+    });
+
+    it('should fall back to filename when ISO-8859-1 filename* is malformed', function () {
+      assert.deepEqual(
+        parse("attachment; filename=\"invoice.pdf\"; filename*=ISO-8859-1''report%2"),
+        {
+          type: 'attachment',
+          parameters: {
+            filename: 'invoice.pdf',
+            'filename*': "ISO-8859-1''report%2",
+          },
+        },
+      );
+    });
+
     it('should not be case-sensitive for charset', function () {
       assert.deepEqual(
         parse("attachment; filename*=utf-8''%E2%82%AC%20rates.pdf"),

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -267,7 +267,9 @@ describe('parse(string)', function () {
 
     it('should fall back to filename when ISO-8859-1 filename* is malformed', function () {
       assert.deepEqual(
-        parse("attachment; filename=\"invoice.pdf\"; filename*=ISO-8859-1''report%2"),
+        parse(
+          'attachment; filename="invoice.pdf"; filename*=ISO-8859-1\'\'report%2',
+        ),
         {
           type: 'attachment',
           parameters: {


### PR DESCRIPTION
### Problem

`decodeExtended()` handles a malformed percent-encoding (a `%` not followed by two hex digits) inconsistently between the two RFC 8187 charsets:

- **UTF-8** path → `decodeURIComponent` throws → the value is rejected (`undefined`).
- **ISO-8859-1** path (`decodeHexEscapes`) → keeps the literal `%` and returns a string.

RFC 8187 §3.2.1 defines `value-chars = *( pct-encoded / attr-char )` with `pct-encoded = "%" HEXDIG HEXDIG`, and `attr-char` does not include `%`, so a bare or short `%` is non-conformant for **both** charsets; the two paths should behave the same.

Because a successfully decoded `filename*` overrides `filename` (RFC 6266 §4.3), the lenient ISO-8859-1 path lets a malformed `filename*` clobber a valid `filename` fallback:

```js
parse('attachment; filename="invoice.pdf"; filename*=ISO-8859-1\'\'report%2').parameters.filename
// before: 'report%2'   (malformed ext-value overrides the fallback)
// after:  'invoice.pdf'
```

This asymmetry was introduced in #127, which tightened only the UTF-8 branch.

### Fix

Make `decodeHexEscapes` return `undefined` on a malformed percent-encoding, mirroring the UTF-8 path. `decodeExtended` already propagates `undefined`, so the unprocessable ext-value is ignored and the `filename` fallback is preserved. Valid percent-encoding and bare-ASCII ext-values are unaffected.

### Verification

- Two new tests: a malformed ISO-8859-1 `filename*` is ignored, and a valid `filename` fallback is preserved. Both fail on the base branch and pass with the fix.
- Independent RFC 8187 §3.2.1 reference decoder, fuzzed over malformed/valid percent inputs: the ISO-8859-1 path now matches the reference (0 divergences) and agrees with the UTF-8 path on the reject decision; previously-valid inputs are unchanged.
- Full suite: 193/193 (191 existing + 2 new).