### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "project": [
       "tsconfig.build.json"
     ]
+  },
+  "homepage": "https://github.com/jshttp/content-disposition",
+  "bugs": {
+    "url": "https://github.com/jshttp/content-disposition/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.