### PR TITLE
fix: parse parameter continuations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ parameter name. This will return an object with the following properties:
   always lower case and extended versions replace non-extended versions). Example:
   `{filename: "€ rates.txt"}`
 
+RFC 2231 parameter continuations, such as `filename*0` and `filename*1`, are
+assembled into the base parameter when all continuation parts are present.
+
 #### Options
 
 ##### multipart

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,11 @@ export function parse(
         if (parameters[key] === undefined) {
           parameters[key] = value;
 
-          if (extended && key.charCodeAt(key.length - 1) === ASTERISK) {
+          if (
+            extended &&
+            key.charCodeAt(key.length - 1) === ASTERISK &&
+            !CONTINUATION_REGEXP.test(key)
+          ) {
             const normalizedKey = key.slice(0, -1);
             const decoded = decodeExtended(value);
             if (decoded !== undefined) parameters[normalizedKey] = decoded;
@@ -186,7 +190,77 @@ export function parse(
     }
   }
 
+  if (extended) resolveContinuations(parameters);
+
   return { type, parameters };
+}
+
+interface ContinuationPart {
+  key: string;
+  value: string;
+  index: number;
+  encoded: boolean;
+}
+
+const CONTINUATION_REGEXP = /^(.+)\*(0|[1-9]\d*)(\*)?$/;
+
+/**
+ * Resolve RFC 2231 parameter continuations into their base parameter.
+ */
+function resolveContinuations(parameters: Record<string, string>): void {
+  const continuations: Record<string, ContinuationPart[]> = new NullObject();
+
+  for (const key of Object.keys(parameters)) {
+    const match = CONTINUATION_REGEXP.exec(key);
+    if (!match) continue;
+
+    const base = match[1];
+    const parts = continuations[base] || (continuations[base] = []);
+
+    parts.push({
+      key,
+      value: parameters[key],
+      index: Number.parseInt(match[2], 10),
+      encoded: match[3] === '*',
+    });
+  }
+
+  for (const base of Object.keys(continuations)) {
+    if (parameters[base + '*'] !== undefined) continue;
+
+    const parts = continuations[base].sort((a, b) => a.index - b.index);
+    if (parts.length < 2) continue;
+    if (!isContiguousContinuation(parts)) continue;
+
+    const encoded = parts[0].encoded;
+    let value: string | undefined;
+
+    if (encoded) {
+      value = decodeExtended(parts.map((part) => part.value).join(''));
+      if (value === undefined) continue;
+    } else {
+      if (parts.some((part) => part.encoded)) continue;
+      if (parameters[base] !== undefined) continue;
+      value = parts.map((part) => part.value).join('');
+    }
+
+    parameters[base] = value;
+
+    for (const part of parts) {
+      delete parameters[part.key];
+    }
+  }
+}
+
+/**
+ * Check that continuation segments start at zero and have no gaps.
+ */
+function isContiguousContinuation(parts: ContinuationPart[]): boolean {
+  for (let index = 0; index < parts.length; index++) {
+    if (parts[index].index !== index) return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -389,6 +389,72 @@ describe('parse(string)', function () {
     });
   });
 
+  describe('with parameter continuations', function () {
+    it('should parse quoted continuation values', function () {
+      assert.deepEqual(
+        parse('attachment; filename*0="foo."; filename*1="html"'),
+        {
+          type: 'attachment',
+          parameters: { filename: 'foo.html' },
+        },
+      );
+    });
+
+    it('should parse token continuation values', function () {
+      assert.deepEqual(parse('attachment; filename*0=foo.; filename*1=html'), {
+        type: 'attachment',
+        parameters: { filename: 'foo.html' },
+      });
+    });
+
+    it('should parse encoded continuation values', function () {
+      assert.deepEqual(
+        parse("attachment; filename*0*=UTF-8''foo-%c3%a4; filename*1=.html"),
+        {
+          type: 'attachment',
+          parameters: { filename: 'foo-ä.html' },
+        },
+      );
+    });
+
+    it('should prefer an encoded continuation over a fallback filename', function () {
+      assert.deepEqual(
+        parse(
+          'attachment; filename="fallback.html"; filename*0*=UTF-8\'\'foo-%c3%a4; filename*1=.html',
+        ),
+        {
+          type: 'attachment',
+          parameters: { filename: 'foo-ä.html' },
+        },
+      );
+    });
+
+    it('should preserve invalid encoded continuation values', function () {
+      assert.deepEqual(
+        parse("attachment; filename*0*=UTF-8''%E4; filename*1=.html"),
+        {
+          type: 'attachment',
+          parameters: {
+            'filename*0*': "UTF-8''%E4",
+            'filename*1': '.html',
+          },
+        },
+      );
+    });
+
+    it('should preserve continuations when "extended" option is false', function () {
+      assert.deepEqual(
+        parse('attachment; filename*0="foo."; filename*1="html"', {
+          extended: false,
+        }),
+        {
+          type: 'attachment',
+          parameters: { 'filename*0': 'foo.', 'filename*1': 'html' },
+        },
+      );
+    });
+  });
+
   describe('from TC 2231', function () {
     describe('Disposition-Type Inline', function () {
       it('should parse "inline"', function () {
@@ -1012,7 +1078,7 @@ describe('parse(string)', function () {
           parse('attachment; filename*0="foo."; filename*1="html"'),
           {
             type: 'attachment',
-            parameters: { 'filename*0': 'foo.', 'filename*1': 'html' },
+            parameters: { filename: 'foo.html' },
           },
         );
       });
@@ -1022,7 +1088,7 @@ describe('parse(string)', function () {
           parse('attachment; filename*0="foo"; filename*1="\\b\\a\\r.html"'),
           {
             type: 'attachment',
-            parameters: { 'filename*0': 'foo', 'filename*1': 'bar.html' },
+            parameters: { filename: 'foobar.html' },
           },
         );
       });
@@ -1034,11 +1100,7 @@ describe('parse(string)', function () {
           ),
           {
             type: 'attachment',
-            parameters: {
-              'filename*0': 'foo-ä',
-              'filename*0*': "UTF-8''foo-%c3%a4",
-              'filename*1': '.html',
-            },
+            parameters: { filename: 'foo-ä.html' },
           },
         );
       });
@@ -1078,7 +1140,7 @@ describe('parse(string)', function () {
           parse('attachment; filename*1="bar"; filename*0="foo"'),
           {
             type: 'attachment',
-            parameters: { 'filename*1': 'bar', 'filename*0': 'foo' },
+            parameters: { filename: 'foobar' },
           },
         );
       });


### PR DESCRIPTION
Fixes #2.

This adds parse-time support for RFC 2231 parameter continuations such as:

```http
Content-Disposition: attachment; filename*0="foo."; filename*1="html"
```

The parser now assembles contiguous continuation parts into the base parameter, including encoded continuations where the first segment carries the RFC 8187 charset/language prefix:

```http
Content-Disposition: attachment; filename*0*=UTF-8''foo-%c3%a4; filename*1=".html"
```

Invalid, incomplete, or disabled extended continuations preserve the raw segment parameters rather than silently producing a decoded value.

Validation:

- `npx vitest run src/parse.spec.ts`
- `npm test`
- `npm run build`
- `git diff --check`

Note: `npm run lint` currently exits with `Script does not exist: lint` from the installed `@borderless/ts-scripts@0.15.0`, so it was not usable as a verification command in this clone.
