### PR TITLE
Do not repeat an extended parameter in format

### DIFF
--- a/src/format.spec.ts
+++ b/src/format.spec.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from 'vitest';
-import { format } from './index';
+import { format, parse } from './index';
 
 describe('format(obj)', function () {
   it('should format a header with only type', function () {
@@ -63,6 +63,53 @@ describe('format(obj)', function () {
         parameters: { filename: '€ rates.pdf' },
       }),
       "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+    );
+  });
+
+  it('should not repeat an extended parameter that is already present', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: {
+          filename: '€ rates.pdf',
+          'filename*': "UTF-8''%E2%82%AC%20rates.pdf",
+        },
+      }),
+      "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+    );
+  });
+
+  it('should not repeat an extended parameter listed before its value', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: {
+          'filename*': "UTF-8''%E2%82%AC%20rates.pdf",
+          filename: '€ rates.pdf',
+        },
+      }),
+      "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+    );
+  });
+
+  it('should format the result of parse without repeating a parameter', function () {
+    assert.strictEqual(
+      format(
+        parse(
+          'attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf',
+        ),
+      ),
+      "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+    );
+  });
+
+  it('should not add a second asterisk to an extended parameter name', function () {
+    assert.strictEqual(
+      format({
+        type: 'attachment',
+        parameters: { 'filename*': "UTF-8''€ rates.pdf" },
+      }),
+      "attachment; filename*=UTF-8''UTF-8%27%27%E2%82%AC%20rates.pdf",
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,18 @@ export function format(
         throw new TypeError('Invalid parameter value: ' + value);
       }
 
-      result += '; ' + param + '*=' + encodeExtended(value);
+      // The extended form of `param` is `param*`, and a name already ending in
+      // `*` is that form. Skip when the object holds the extended name itself
+      // (e.g. every object returned by `parse`), as it is written out from its
+      // own entry and a header must not repeat a parameter name.
+      const extendedParam =
+        param.charCodeAt(param.length - 1) === ASTERISK ? param : param + '*';
+
+      if (extendedParam !== param && parameters[extendedParam] !== undefined) {
+        continue;
+      }
+
+      result += '; ' + extendedParam + '=' + encodeExtended(value);
     }
   }
 


### PR DESCRIPTION
`parse` and `format` share the `ContentDisposition` shape, so feeding one into the other is the natural way to normalize or edit an incoming header. That composition currently produces an invalid header whenever an extended parameter is involved.

`parse` intentionally keeps the raw extended parameter *and* publishes its decoded value under the plain name:

```js
parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
// { type: 'attachment', parameters: {
//     'filename*': "UTF-8''%E2%82%AC%20rates.pdf",
//     filename: '€ rates.pdf' } }
```

`format` then walks those two entries independently. It emits `filename*` verbatim (it is a valid token), and separately re-encodes `filename` — whose value is Unicode — into `filename*` again:

```js
format(parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf"));
// attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf; filename*=UTF-8''%E2%82%AC%20rates.pdf

format(parse('attachment; filename="EURO rates.pdf"; filename*=UTF-8\'\'%E2%82%AC%20rates.pdf'));
// attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf; filename*=UTF-8''%E2%82%AC%20rates.pdf
```

RFC 6266 §4.1: "Content-Disposition header field values with multiple instances of the same parameter name are invalid."

The same code path can also invent a parameter name. When the name already ends in `*`, another `*` is appended, so the value lands under a *different* parameter and the file name is gone on the next parse:

```js
format({ type: 'attachment', parameters: { 'filename*': "UTF-8''€ rates.pdf" } });
// attachment; filename**=UTF-8''UTF-8%27%27%E2%82%AC%20rates.pdf

parse('attachment; filename**=UTF-8\'\'UTF-8%27%27%E2%82%AC%20rates.pdf').parameters.filename;
// undefined
```

## Fix

Resolve the extended name before writing it (`param` when it already ends in `*`, `param*` otherwise) and skip the generated parameter when the object already carries that name — that entry writes itself out from its own iteration, so the explicit, pre-encoded value wins and nothing is duplicated:

```js
format(parse("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf"));
// attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf
```

Preferring the explicit `param*` entry over the generated one keeps information that re-encoding would drop, such as the charset and the language tag in `filename*=UTF-8'en'…`.

Nothing else changes. `create` is unaffected: its ASCII fallback (`filename="? rates.pdf"; filename*=UTF-8''…`) is two different parameter names, and the fallback value is US-ASCII, so it never reaches this branch. Values that are Latin-1 (`filename*=ISO-8859-1''%A3%20rates.pdf` → `filename="£ rates.pdf"`) are quoted rather than encoded and are likewise untouched.

## Tests

Four cases added to `format.spec.ts`, red before the change and green after: the duplicate in both key orders, `format(parse(header))` for the header used in the README, and the `filename**` name. Full suite is 197 passing with coverage still at 100%.
